### PR TITLE
Add MMEL 0.1 spec parity: note, table, figure, link, map_profile, view_profile, parallel_gateway

### DIFF
--- a/packages/mmel/src/ser-des/config/calculation.ts
+++ b/packages/mmel/src/ser-des/config/calculation.ts
@@ -1,0 +1,147 @@
+import type { Dumper, Parser, Resolver } from '../types';
+import { removePackage, tokenizePackage } from '../tokenize';
+import type Calculation from '../../types/Calculation';
+import type { CalculationInput, CalculationOutput, ResolvableCalculation } from '../../types/Calculation';
+import { resolveFromContext } from '../resolve';
+
+export const parseCalculation: Parser = function (id, data) {
+  const result: ResolvableCalculation = {
+    id,
+    name: '',
+    description: '',
+    inputs: [],
+    output: { type: 'number', unit: '1' },
+    expression: '',
+    ref: [],
+    _relations: {
+      ref: [],
+    },
+  };
+
+  if (data !== '') {
+    const t: Array<string> = tokenizePackage(data);
+    let i = 0;
+    while (i < t.length) {
+      const command: string = t[i++];
+      if (i < t.length) {
+        if (command === 'name') {
+          result.name = removePackage(t[i++]);
+        } else if (command === 'description') {
+          result.description = removePackage(t[i++]);
+        } else if (command === 'expression') {
+          result.expression = removePackage(t[i++]);
+        } else if (command === 'reference') {
+          result._relations.ref = tokenizePackage(t[i++]);
+        } else if (command === 'inputs') {
+          result.inputs = parseInputs(removePackage(t[i++]), id);
+        } else if (command === 'output') {
+          result.output = parseOutput(removePackage(t[i++]), id);
+        } else {
+          throw new Error(`Parsing error: calculation. ID ${id}: Unknown keyword ${command}`);
+        }
+      } else {
+        throw new Error(`Parsing error: calculation. ID ${id}: Expecting value for ${command}`);
+      }
+    }
+  }
+
+  return ctx => ({ ...ctx, calculations: { ...ctx.calculations, [id]: result } });
+};
+
+function parseInputs(block: string, parentId: string): CalculationInput[] {
+  const inputs: CalculationInput[] = [];
+  // inputs block contains entries like: `name : type { unit "..." description "..." default <v> }`
+  // We tokenize the block and walk through it
+  const t = tokenizePackage(block);
+  let i = 0;
+  while (i < t.length) {
+    const name = t[i++];
+    if (i >= t.length) break;
+    // Expect ':' then type
+    if (t[i] === ':') i++;
+    const type = i < t.length ? t[i++] : 'number';
+    // Optional brace block with properties
+    let unit = '1';
+    let description = '';
+    let defaultValue = '';
+    let hasDefault = false;
+    if (i < t.length && t[i].startsWith('{')) {
+      const propBlock = removePackage(t[i++]);
+      const pt = tokenizePackage(propBlock);
+      let j = 0;
+      while (j < pt.length) {
+        const cmd = pt[j++];
+        if (j < pt.length) {
+          if (cmd === 'unit') unit = removePackage(pt[j++]);
+          else if (cmd === 'description') description = removePackage(pt[j++]);
+          else if (cmd === 'default') {
+            defaultValue = removePackage(pt[j++]);
+            hasDefault = true;
+          } else {
+            j++; // skip unknown
+          }
+        }
+      }
+    }
+    inputs.push({ name, type, unit, description, defaultValue, hasDefault });
+  }
+  return inputs;
+}
+
+function parseOutput(block: string, parentId: string): CalculationOutput {
+  // output block: `: type { unit "..." }`
+  const t = tokenizePackage(block);
+  let i = 0;
+  let type = 'number';
+  let unit = '1';
+  if (t[i] === ':') i++;
+  if (i < t.length) type = t[i++];
+  if (i < t.length && t[i].startsWith('{')) {
+    const propBlock = removePackage(t[i++]);
+    const pt = tokenizePackage(propBlock);
+    let j = 0;
+    while (j < pt.length) {
+      const cmd = pt[j++];
+      if (j < pt.length) {
+        if (cmd === 'unit') unit = removePackage(pt[j++]);
+        else j++;
+      }
+    }
+  }
+  return { type, unit };
+}
+
+export const resolveCalculation: Resolver<Calculation, ResolvableCalculation> = function (ctx, unresolved) {
+  const resolved: Calculation = { ...unresolved, ref: [] };
+  for (const id of unresolved._relations.ref) {
+    resolved.ref.push(resolveFromContext(ctx, 'references', id));
+  }
+  return resolved;
+};
+
+export const dumpCalculation: Dumper<Calculation> = function (c) {
+  let out = 'calculation ' + c.id + ' {\n';
+  out += '  name "' + c.name + '"\n';
+  if (c.description) out += '  description "' + c.description + '"\n';
+  if (c.inputs.length > 0) {
+    out += '  inputs {\n';
+    for (const inp of c.inputs) {
+      let line = '    ' + inp.name + ' : ' + inp.type + ' { ';
+      line += 'unit "' + inp.unit + '"';
+      if (inp.description) line += ' description "' + inp.description + '"';
+      if (inp.hasDefault) line += ' default ' + inp.defaultValue;
+      line += ' }\n';
+      out += line;
+    }
+    out += '  }\n';
+  }
+  out += '  output : ' + c.output.type + ' { unit "' + c.output.unit + '" }\n';
+  out += '  expression "' + c.expression + '"\n';
+  if (c.ref.length > 0) {
+    out += '  reference {\n';
+    for (const r of c.ref) out += '    ' + r.id + '\n';
+    out += '  }\n';
+  }
+  out += '}\n';
+  return out;
+};

--- a/packages/mmel/src/ser-des/config/figure.ts
+++ b/packages/mmel/src/ser-des/config/figure.ts
@@ -1,0 +1,36 @@
+import type { Dumper, Parser } from '../types';
+import { removePackage, tokenizePackage } from '../tokenize';
+import type Figure from '../../types/Figure';
+
+export const parseFigure: Parser = function (id, data) {
+  const result: Figure = { id, title: '', src: '' };
+
+  if (data !== '') {
+    const t: Array<string> = tokenizePackage(data);
+    let i = 0;
+    while (i < t.length) {
+      const command: string = t[i++];
+      if (i < t.length) {
+        if (command === 'title') {
+          result.title = removePackage(t[i++]);
+        } else if (command === 'src') {
+          result.src = removePackage(t[i++]);
+        } else {
+          throw new Error(`Parsing error: figure. ID ${id}: Unknown keyword ${command}`);
+        }
+      } else {
+        throw new Error(`Parsing error: figure. ID ${id}: Expecting value for ${command}`);
+      }
+    }
+  }
+
+  return ctx => ({ ...ctx, figures: { ...ctx.figures, [id]: result } });
+};
+
+export const dumpFigure: Dumper<Figure> = function (f) {
+  let out = 'figure ' + f.id + ' {\n';
+  out += '  title "' + f.title + '"\n';
+  out += '  src "' + f.src + '"\n';
+  out += '}\n';
+  return out;
+};

--- a/packages/mmel/src/ser-des/config/form.ts
+++ b/packages/mmel/src/ser-des/config/form.ts
@@ -1,0 +1,273 @@
+import type { Dumper, Parser } from '../types';
+import { removePackage, tokenizePackage } from '../tokenize';
+import type Form from '../../types/Form';
+import type { FormField, ApplicabilityEntry, PassFail, SubformRef } from '../../types/Form';
+
+export const parseForm: Parser = function (id, data) {
+  const result: Form = {
+    id,
+    name: '',
+    description: '',
+    dataClassId: '',
+    headerFormId: '',
+    conformanceProcessId: '',
+    applicability: [],
+    fields: [],
+    passFail: null,
+    referenceIds: [],
+    ref: [],
+  };
+
+  if (data !== '') {
+    const t: Array<string> = tokenizePackage(data);
+    let i = 0;
+    while (i < t.length) {
+      const command: string = t[i++];
+      if (i < t.length) {
+        if (command === 'name') {
+          result.name = removePackage(t[i++]);
+        } else if (command === 'description') {
+          result.description = removePackage(t[i++]);
+        } else if (command === 'data_class') {
+          result.dataClassId = removePackage(t[i++]);
+        } else if (command === 'header') {
+          result.headerFormId = removePackage(t[i++]);
+        } else if (command === 'conformance_process') {
+          result.conformanceProcessId = removePackage(t[i++]);
+        } else if (command === 'applicability') {
+          result.applicability = parseApplicability(removePackage(t[i++]));
+        } else if (command === 'field') {
+          const fieldName = t[i++];
+          if (i < t.length) {
+            const fieldBlock = removePackage(t[i++]);
+            result.fields.push(parseFormField(fieldName, fieldBlock));
+          }
+        } else if (command === 'subform_ref') {
+          // subform_ref SubformID { parameters { ... } applicability { ... } }
+          const subformId = t[i++];
+          const refBlock = i < t.length ? removePackage(t[i++]) : '';
+          result.fields.push(makeSubformRefField(subformId, refBlock));
+        } else if (command === 'pass_fail') {
+          result.passFail = parsePassFail(removePackage(t[i++]));
+        } else if (command === 'reference') {
+          result.referenceIds = tokenizePackage(t[i++]);
+        } else {
+          throw new Error(`Parsing error: form. ID ${id}: Unknown keyword ${command}`);
+        }
+      } else {
+        throw new Error(`Parsing error: form. ID ${id}: Expecting value for ${command}`);
+      }
+    }
+  }
+
+  return ctx => ({ ...ctx, forms: { ...ctx.forms, [id]: result } });
+};
+
+function parseApplicability(block: string): ApplicabilityEntry[] {
+  const entries: ApplicabilityEntry[] = [];
+  const t = tokenizePackage(block);
+  let i = 0;
+  while (i < t.length) {
+    const dimension = t[i++];
+    if (i >= t.length) break;
+    if (t[i] === ':') i++;
+    if (i < t.length) {
+      const valueBlock = removePackage(t[i++]);
+      // valueBlock is `[A, B]` or `{ A: 5, B: 5 }`
+      const trimmed = valueBlock.trim();
+      if (trimmed.startsWith('[')) {
+        const inner = trimmed.slice(1, -1);
+        const values = inner.split(/[,\s]+/).filter(s => s.length > 0);
+        entries.push({ dimension, values, mapping: null });
+      } else if (trimmed.startsWith('{')) {
+        // Mapping form
+        const inner = trimmed.slice(1, -1);
+        const mapping: Record<string, string | number> = {};
+        for (const pair of inner.split(/[,\n]+/).map(s => s.trim()).filter(s => s)) {
+          const m = pair.match(/^(\w+)\s*:\s*(.+)$/);
+          if (m) mapping[m[1]] = m[2].trim();
+        }
+        entries.push({ dimension, values: [], mapping });
+      } else {
+        // Single value
+        entries.push({ dimension, values: [trimmed], mapping: null });
+      }
+    }
+  }
+  return entries;
+}
+
+function parsePassFail(block: string): PassFail {
+  const pf: PassFail = { criteria: '', passIf: '' };
+  const t = tokenizePackage(block);
+  let i = 0;
+  while (i < t.length) {
+    const cmd = t[i++];
+    if (i < t.length) {
+      if (cmd === 'criteria') pf.criteria = removePackage(t[i++]);
+      else if (cmd === 'pass_if') pf.passIf = removePackage(t[i++]);
+      else removePackage(t[i++]);
+    }
+  }
+  return pf;
+}
+
+function parseFormField(name: string, block: string): FormField {
+  const field: FormField = {
+    name,
+    type: 'string',
+    label: '',
+    definition: '',
+    unit: '',
+    required: false,
+    measurementMethod: '',
+    calculationId: null,
+    calculationBindings: [],
+    derivation: '',
+    evaluation: null,
+    values: [],
+    defaultValue: '',
+    hasDefault: false,
+    referenceIds: [],
+    fields: [],
+    itemsType: '',
+    subformRef: null,
+  };
+  // Same field parsing as subform.ts (kept inline to avoid circular imports)
+  if (block && block.trim()) {
+    const t = tokenizePackage(block);
+    let i = 0;
+    while (i < t.length) {
+      const cmd = t[i++];
+      if (i < t.length) {
+        if (cmd === 'label') field.label = removePackage(t[i++]);
+        else if (cmd === 'definition') field.definition = removePackage(t[i++]);
+        else if (cmd === 'unit') field.unit = removePackage(t[i++]);
+        else if (cmd === 'required') field.required = removePackage(t[i++]) === 'true';
+        else if (cmd === 'measurement_method') field.measurementMethod = removePackage(t[i++]);
+        else if (cmd === 'calculation') field.calculationId = removePackage(t[i++]);
+        else if (cmd === 'calculation_bindings') removePackage(t[i++]);
+        else if (cmd === 'derivation') field.derivation = removePackage(t[i++]);
+        else if (cmd === 'evaluation') removePackage(t[i++]);
+        else if (cmd === 'values') field.values = tokenizePackage(t[i++]);
+        else if (cmd === 'default') {
+          field.defaultValue = removePackage(t[i++]);
+          field.hasDefault = true;
+        } else if (cmd === 'min_items' || cmd === 'max_items') {
+          removePackage(t[i++]);
+        } else if (cmd === 'items' || cmd === 'fields') {
+          removePackage(t[i++]);
+        } else if (cmd === 'reference') {
+          field.referenceIds = tokenizePackage(t[i++]);
+        } else {
+          removePackage(t[i++]);
+        }
+      }
+    }
+  }
+  return field;
+}
+
+function makeSubformRefField(subformId: string, block: string): FormField {
+  const field: FormField = {
+    name: '', // caller wraps this in a named field
+    type: 'array',
+    label: '',
+    definition: '',
+    unit: '',
+    required: false,
+    measurementMethod: '',
+    calculationId: null,
+    calculationBindings: [],
+    derivation: '',
+    evaluation: null,
+    values: [],
+    defaultValue: '',
+    hasDefault: false,
+    referenceIds: [],
+    fields: [],
+    itemsType: '',
+    subformRef: parseSubformRef(subformId, block),
+  };
+  return field;
+}
+
+function parseSubformRef(subformId: string, block: string): SubformRef {
+  const ref: SubformRef = {
+    subformId,
+    parameters: {},
+    applicability: [],
+  };
+  if (block && block.trim()) {
+    const t = tokenizePackage(block);
+    let i = 0;
+    while (i < t.length) {
+      const cmd = t[i++];
+      if (i < t.length) {
+        if (cmd === 'parameters') {
+          const pblock = removePackage(t[i++]);
+          const pt = tokenizePackage(pblock);
+          let j = 0;
+          while (j < pt.length) {
+            const key = pt[j++];
+            if (j < pt.length) {
+              if (pt[j] === ':') j++;
+              if (j < pt.length) ref.parameters[key] = removePackage(pt[j++]);
+            }
+          }
+        } else if (cmd === 'applicability') {
+          ref.applicability = parseApplicability(removePackage(t[i++]));
+        } else {
+          removePackage(t[i++]);
+        }
+      }
+    }
+  }
+  return ref;
+}
+
+export const dumpForm: Dumper<Form> = function (f) {
+  let out = 'form ' + f.id + ' {\n';
+  out += '  name "' + f.name + '"\n';
+  if (f.description) out += '  description "' + f.description + '"\n';
+  if (f.dataClassId) out += '  data_class ' + f.dataClassId + '\n';
+  if (f.headerFormId) out += '  header ' + f.headerFormId + '\n';
+  if (f.conformanceProcessId) out += '  conformance_process ' + f.conformanceProcessId + '\n';
+  if (f.applicability.length > 0) {
+    out += '  applicability {\n';
+    for (const a of f.applicability) {
+      if (a.mapping) {
+        out += '    ' + a.dimension + ': { ';
+        for (const [k, v] of Object.entries(a.mapping)) out += k + ': ' + v + ' ';
+        out += '}\n';
+      } else {
+        out += '    ' + a.dimension + ': [' + a.values.join(', ') + ']\n';
+      }
+    }
+    out += '  }\n';
+  }
+  for (const field of f.fields) {
+    if (field.subformRef) {
+      const sr = field.subformRef;
+      out += '  subform_ref ' + sr.subformId + ' { ';
+      const pkeys = Object.keys(sr.parameters);
+      if (pkeys.length > 0) {
+        out += 'parameters { ';
+        for (const k of pkeys) out += k + ': ' + sr.parameters[k] + ' ';
+        out += '} ';
+      }
+      out += '}\n';
+    } else {
+      out += '  field ' + field.name + ' { ';
+      if (field.label) out += 'label "' + field.label + '" ';
+      if (field.unit) out += 'unit "' + field.unit + '" ';
+      if (field.required) out += 'required true ';
+      out += '}\n';
+    }
+  }
+  if (f.passFail) {
+    out += '  pass_fail { criteria "' + f.passFail.criteria + '" pass_if "' + f.passFail.passIf + '" }\n';
+  }
+  out += '}\n';
+  return out;
+};

--- a/packages/mmel/src/ser-des/config/index.ts
+++ b/packages/mmel/src/ser-des/config/index.ts
@@ -32,8 +32,16 @@ import {
   dumpSubprocess,
 } from './process';
 import { parseProvision, resolveProvision, dumpProvision } from './provision';
-import { dumpReference } from './reference';
+import { dumpReference, parseReference } from './reference';
 import { parseRole, dumpRole } from './role';
+
+// MMEL 0.1 spec-parity parsers/dumpers
+import { dumpNote, parseNote, resolveNote } from './note';
+import { dumpTable, parseTable } from './table';
+import { dumpFigure, parseFigure } from './figure';
+import { dumpLink, parseLink } from './link';
+import { dumpMapProfile, parseMapProfile } from './mapProfile';
+import { dumpViewProfile, parseViewProfile } from './viewProfile';
 
 export const PARSER_CONFIG: ParserConfiguration = {
   root: {
@@ -102,6 +110,37 @@ export const PARSER_CONFIG: ParserConfiguration = {
     takesID: true,
     parse: parseTimerEvent,
   },
+
+  reference: {
+    takesID: true,
+    parse: parseReference,
+  },
+
+  // ── MMEL 0.1 spec-parity additions ───────────────────────────────
+  note: {
+    takesID: true,
+    parse: parseNote,
+  },
+  table: {
+    takesID: true,
+    parse: parseTable,
+  },
+  figure: {
+    takesID: true,
+    parse: parseFigure,
+  },
+  link: {
+    takesID: true,
+    parse: parseLink,
+  },
+  map_profile: {
+    takesID: true,
+    parse: parseMapProfile,
+  },
+  view_profile: {
+    takesID: true,
+    parse: parseViewProfile,
+  },
 };
 
 export const RESOLVER_CONFIG: ResolverConfiguration = {
@@ -119,6 +158,9 @@ export const RESOLVER_CONFIG: ResolverConfiguration = {
   },
   registers: {
     resolve: resolveRegistry,
+  },
+  notes: {
+    resolve: resolveNote,
   },
 };
 
@@ -214,4 +256,12 @@ export const DUMPER_CONFIG: DumperConfiguration = {
   pages: dumpSubprocess,
   vars: dumpVariable,
   refs: dumpReference,
+
+  // MMEL 0.1 spec-parity dumpers
+  notes: dumpNote,
+  tables: dumpTable,
+  figures: dumpFigure,
+  links: dumpLink,
+  mapProfiles: dumpMapProfile,
+  viewProfiles: dumpViewProfile,
 };

--- a/packages/mmel/src/ser-des/config/index.ts
+++ b/packages/mmel/src/ser-des/config/index.ts
@@ -43,6 +43,13 @@ import { dumpLink, parseLink } from './link';
 import { dumpMapProfile, parseMapProfile } from './mapProfile';
 import { dumpViewProfile, parseViewProfile } from './viewProfile';
 
+// Primmel extension parsers/dumpers (MN 113-7 to 113-10)
+import { dumpForm, parseForm } from './form';
+import { dumpSubformType as dumpSubform, parseSubform } from './subform';
+import { dumpSymbol, parseSymbol, resolveSymbol } from './symbol';
+import { dumpCalculation, parseCalculation, resolveCalculation } from './calculation';
+import { dumpStateMachine, parseStateMachine } from './stateMachine';
+
 export const PARSER_CONFIG: ParserConfiguration = {
   root: {
     parse: token => ctx => ({ ...ctx, root: token.trim() }),
@@ -141,6 +148,28 @@ export const PARSER_CONFIG: ParserConfiguration = {
     takesID: true,
     parse: parseViewProfile,
   },
+
+  // ── Primmel extension additions (MN 113-7 to 113-10) ─────────────
+  form: {
+    takesID: true,
+    parse: parseForm,
+  },
+  subform: {
+    takesID: true,
+    parse: parseSubform,
+  },
+  symbol: {
+    takesID: true,
+    parse: parseSymbol,
+  },
+  calculation: {
+    takesID: true,
+    parse: parseCalculation,
+  },
+  state_machine: {
+    takesID: true,
+    parse: parseStateMachine,
+  },
 };
 
 export const RESOLVER_CONFIG: ResolverConfiguration = {
@@ -161,6 +190,12 @@ export const RESOLVER_CONFIG: ResolverConfiguration = {
   },
   notes: {
     resolve: resolveNote,
+  },
+  symbols: {
+    resolve: resolveSymbol,
+  },
+  calculations: {
+    resolve: resolveCalculation,
   },
 };
 
@@ -264,4 +299,11 @@ export const DUMPER_CONFIG: DumperConfiguration = {
   links: dumpLink,
   mapProfiles: dumpMapProfile,
   viewProfiles: dumpViewProfile,
+
+  // Primmel extension dumpers
+  forms: dumpForm,
+  subforms: dumpSubform,
+  symbols: dumpSymbol,
+  calculations: dumpCalculation,
+  stateMachines: dumpStateMachine,
 };

--- a/packages/mmel/src/ser-des/config/link.ts
+++ b/packages/mmel/src/ser-des/config/link.ts
@@ -1,0 +1,48 @@
+import type { Dumper, Parser } from '../types';
+import { removePackage, tokenizePackage } from '../tokenize';
+import type Link from '../../types/Link';
+import type { LinkKind } from '../../types/Link';
+
+const VALID_LINK_KINDS: LinkKind[] = ['REPO', 'URL'];
+
+export const parseLink: Parser = function (id, data) {
+  const result: Link = { id, kind: 'URL', target: '', namespace: '' };
+
+  if (data !== '') {
+    const t: Array<string> = tokenizePackage(data);
+    let i = 0;
+    while (i < t.length) {
+      const command: string = t[i++];
+      if (i < t.length) {
+        if (command === 'type' || command === 'kind') {
+          const v = t[i++] as LinkKind;
+          if (!VALID_LINK_KINDS.includes(v)) {
+            throw new Error(
+              `Parsing error: link. ID ${id}: Unknown kind ${v} (valid: ${VALID_LINK_KINDS.join(', ')})`
+            );
+          }
+          result.kind = v;
+        } else if (command === 'target' || command === 'path' || command === 'url') {
+          result.target = removePackage(t[i++]);
+        } else if (command === 'namespace' || command === 'ns') {
+          result.namespace = removePackage(t[i++]);
+        } else {
+          throw new Error(`Parsing error: link. ID ${id}: Unknown keyword ${command}`);
+        }
+      } else {
+        throw new Error(`Parsing error: link. ID ${id}: Expecting value for ${command}`);
+      }
+    }
+  }
+
+  return ctx => ({ ...ctx, links: { ...ctx.links, [id]: result } });
+};
+
+export const dumpLink: Dumper<Link> = function (l) {
+  let out = 'link ' + l.id + ' {\n';
+  out += '  type ' + l.kind + '\n';
+  out += '  target "' + l.target + '"\n';
+  if (l.namespace) out += '  namespace "' + l.namespace + '"\n';
+  out += '}\n';
+  return out;
+};

--- a/packages/mmel/src/ser-des/config/mapProfile.ts
+++ b/packages/mmel/src/ser-des/config/mapProfile.ts
@@ -1,0 +1,50 @@
+import type { Dumper, Parser } from '../types';
+import { removePackage, tokenizePackage } from '../tokenize';
+import type MapProfile from '../../types/MapProfile';
+
+export const parseMapProfile: Parser = function (namespace, data) {
+  const result: MapProfile = {
+    namespace,
+    description: '',
+    mappings: {},
+  };
+
+  if (data !== '') {
+    const t: Array<string> = tokenizePackage(data);
+    let i = 0;
+    while (i < t.length) {
+      const command: string = t[i++];
+      if (i < t.length) {
+        if (command === 'description') {
+          result.description = removePackage(t[i++]);
+        } else if (command === 'mapping') {
+          // mapping block: source → target pairs
+          const block = removePackage(t[i++]);
+          for (const line of block.split(/\n+/).map(s => s.trim()).filter(s => s)) {
+            const m = line.match(/^(\S+)\s*->\s*(\S+)$/);
+            if (m) result.mappings[m[1]] = m[2];
+          }
+        } else {
+          throw new Error(`Parsing error: map_profile. NS ${namespace}: Unknown keyword ${command}`);
+        }
+      } else {
+        throw new Error(`Parsing error: map_profile. NS ${namespace}: Expecting value for ${command}`);
+      }
+    }
+  }
+
+  return ctx => ({ ...ctx, mapProfiles: { ...ctx.mapProfiles, [namespace]: result } });
+};
+
+export const dumpMapProfile: Dumper<MapProfile> = function (mp) {
+  let out = 'map_profile ' + mp.namespace + ' {\n';
+  if (mp.description) out += '  description "' + mp.description + '"\n';
+  const keys = Object.keys(mp.mappings);
+  if (keys.length > 0) {
+    out += '  mapping {\n';
+    for (const k of keys) out += '    ' + k + ' -> ' + mp.mappings[k] + '\n';
+    out += '  }\n';
+  }
+  out += '}\n';
+  return out;
+};

--- a/packages/mmel/src/ser-des/config/note.ts
+++ b/packages/mmel/src/ser-des/config/note.ts
@@ -1,0 +1,70 @@
+import type { Dumper, Parser, Resolver } from '../types';
+import { removePackage, tokenizePackage } from '../tokenize';
+import type Note from '../../types/Note';
+import type { NoteType } from '../../types/Note';
+import { ResolvableNote } from '../../types/Note';
+import { resolveFromContext } from '../resolve';
+
+const VALID_NOTE_TYPES: NoteType[] = ['NOTE', 'CAUTION', 'WARNING'];
+
+export const parseNote: Parser = function (id, data) {
+  const result: ResolvableNote = {
+    id: id,
+    type: 'NOTE',
+    message: '',
+    ref: [],
+    _relations: {
+      ref: [],
+    },
+  };
+
+  if (data !== '') {
+    const t: Array<string> = tokenizePackage(data);
+    let i = 0;
+    while (i < t.length) {
+      const command: string = t[i++];
+      if (i < t.length) {
+        if (command === 'type') {
+          const v = t[i++] as NoteType;
+          if (!VALID_NOTE_TYPES.includes(v)) {
+            throw new Error(
+              `Parsing error: note. ID ${id}: Unknown type ${v} (valid: ${VALID_NOTE_TYPES.join(', ')})`
+            );
+          }
+          result.type = v;
+        } else if (command === 'message') {
+          result.message = removePackage(t[i++]);
+        } else if (command === 'reference') {
+          result._relations.ref = tokenizePackage(t[i++]);
+        } else {
+          throw new Error(`Parsing error: note. ID ${id}: Unknown keyword ${command}`);
+        }
+      } else {
+        throw new Error(`Parsing error: note. ID ${id}: Expecting value for ${command}`);
+      }
+    }
+  }
+
+  return ctx => ({ ...ctx, notes: { ...ctx.notes, [id]: result } });
+};
+
+export const resolveNote: Resolver<Note, ResolvableNote> = function (ctx, unresolved) {
+  const resolved: Note = { ...unresolved, ref: [] };
+  for (const id of unresolved._relations.ref) {
+    resolved.ref.push(resolveFromContext(ctx, 'references', id));
+  }
+  return resolved;
+};
+
+export const dumpNote: Dumper<Note> = function (n) {
+  let out = 'note ' + n.id + ' {\n';
+  out += '  type ' + n.type + '\n';
+  out += '  message "' + n.message + '"\n';
+  if (n.ref.length > 0) {
+    out += '  reference {\n';
+    for (const r of n.ref) out += '    ' + r.id + '\n';
+    out += '  }\n';
+  }
+  out += '}\n';
+  return out;
+};

--- a/packages/mmel/src/ser-des/config/stateMachine.ts
+++ b/packages/mmel/src/ser-des/config/stateMachine.ts
@@ -1,0 +1,139 @@
+import type { Dumper, Parser } from '../types';
+import { removePackage, tokenizePackage } from '../tokenize';
+import type StateMachine from '../../types/StateMachine';
+import type { Transition, Cascade, CascadeSet } from '../../types/StateMachine';
+
+export const parseStateMachine: Parser = function (entityName, data) {
+  const result: StateMachine = {
+    entityName,
+    initialState: '',
+    states: [],
+    transitions: [],
+    referenceIds: [],
+  };
+
+  if (data !== '') {
+    const t: Array<string> = tokenizePackage(data);
+    let i = 0;
+    while (i < t.length) {
+      const command: string = t[i++];
+      if (i < t.length) {
+        if (command === 'initial') {
+          result.initialState = removePackage(t[i++]);
+        } else if (command === 'states') {
+          const stateBlock = removePackage(t[i++]);
+          for (const s of stateBlock.split(/\s+/).filter(s => s.length > 0)) {
+            result.states.push({ name: s });
+          }
+        } else if (command === 'transition') {
+          // transition <From> -> <To> [action <ActionName>] { ... }
+          const from = t[i++];
+          // Expect '->'
+          if (i < t.length && (t[i] === '->' || t[i] === '→')) i++;
+          const to = i < t.length ? t[i++] : '';
+          let actionName = '';
+          // Optional 'action <Name>' before block
+          if (i < t.length && t[i] === 'action') {
+            i++;
+            if (i < t.length) actionName = t[i++];
+          }
+          let guard = '';
+          const cascades: Cascade[] = [];
+          const referenceIds: string[] = [];
+          if (i < t.length && t[i].startsWith('{')) {
+            const body = removePackage(t[i++]);
+            const bt = tokenizePackage(body);
+            let j = 0;
+            while (j < bt.length) {
+              const cmd = bt[j++];
+              if (j < bt.length) {
+                if (cmd === 'guard') guard = removePackage(bt[j++]);
+                else if (cmd === 'cascade') {
+                  const target = bt[j++];
+                  if (j < bt.length) {
+                    const cascadeBlock = removePackage(bt[j++]);
+                    cascades.push(parseCascade(target, cascadeBlock));
+                  }
+                } else if (cmd === 'reference') {
+                  referenceIds.push(...tokenizePackage(bt[j++]));
+                } else {
+                  removePackage(bt[j++]);
+                }
+              }
+            }
+          }
+          const trans: Transition = { from, to, actionName, guard, cascades, referenceIds };
+          result.transitions.push(trans);
+        } else if (command === 'reference') {
+          result.referenceIds.push(...tokenizePackage(t[i++]));
+        } else {
+          throw new Error(`Parsing error: state_machine. Entity ${entityName}: Unknown keyword ${command}`);
+        }
+      } else {
+        throw new Error(`Parsing error: state_machine. Entity ${entityName}: Expecting value for ${command}`);
+      }
+    }
+  }
+
+  return ctx => ({ ...ctx, stateMachines: { ...ctx.stateMachines, [entityName]: result } });
+};
+
+function parseCascade(target: string, block: string): Cascade {
+  const cascade: Cascade = { targetEntity: target, where: '', set: [] };
+  const t = tokenizePackage(block);
+  let i = 0;
+  while (i < t.length) {
+    const cmd = t[i++];
+    if (i < t.length) {
+      if (cmd === 'where') cascade.where = removePackage(t[i++]);
+      else if (cmd === 'set') {
+        const setBlock = removePackage(t[i++]);
+        const st = tokenizePackage(setBlock);
+        let j = 0;
+        while (j < st.length) {
+          const field = st[j++];
+          if (j < st.length) {
+            if (st[j] === ':') j++;
+            if (j < st.length) {
+              const value = removePackage(st[j++]);
+              const setEntry: CascadeSet = { field, value };
+              cascade.set.push(setEntry);
+            }
+          }
+        }
+      } else {
+        removePackage(t[i++]);
+      }
+    }
+  }
+  return cascade;
+}
+
+export const dumpStateMachine: Dumper<StateMachine> = function (sm) {
+  let out = 'state_machine ' + sm.entityName + ' {\n';
+  out += '  initial ' + sm.initialState + '\n';
+  if (sm.states.length > 0) {
+    out += '  states {\n';
+    for (const s of sm.states) out += '    ' + s.name + '\n';
+    out += '  }\n';
+  }
+  for (const t of sm.transitions) {
+    out += '  transition ' + t.from + ' -> ' + t.to;
+    if (t.actionName) out += ' action ' + t.actionName;
+    out += ' {\n';
+    if (t.guard) out += '    guard "' + t.guard + '"\n';
+    for (const c of t.cascades) {
+      out += '    cascade ' + c.targetEntity + ' {\n';
+      if (c.where) out += '      where "' + c.where + '"\n';
+      if (c.set.length > 0) {
+        out += '      set {\n';
+        for (const s of c.set) out += '        ' + s.field + ': "' + s.value + '"\n';
+        out += '      }\n';
+      }
+      out += '    }\n';
+    }
+    out += '  }\n';
+  }
+  out += '}\n';
+  return out;
+};

--- a/packages/mmel/src/ser-des/config/subform.ts
+++ b/packages/mmel/src/ser-des/config/subform.ts
@@ -1,0 +1,195 @@
+import type { Dumper, Parser } from '../types';
+import { removePackage, tokenizePackage } from '../tokenize';
+import type Subform from '../../types/Subform';
+import type { ParameterDecl } from '../../types/Subform';
+import type { FormField } from '../../types/Form';
+
+export const parseSubform: Parser = function (id, data) {
+  const result: Subform = {
+    id,
+    description: '',
+    shapeType: 'object',
+    parameters: [],
+    fields: [],
+  };
+
+  if (data !== '') {
+    const t: Array<string> = tokenizePackage(data);
+    let i = 0;
+    while (i < t.length) {
+      const command: string = t[i++];
+      if (i < t.length) {
+        if (command === 'description') {
+          result.description = removePackage(t[i++]);
+        } else if (command === 'type') {
+          const v = removePackage(t[i++]);
+          if (v === 'object' || v === 'array') result.shapeType = v;
+          else throw new Error(`Parsing error: subform. ID ${id}: type must be object or array (got ${v})`);
+        } else if (command === 'parameters') {
+          result.parameters = parseParameters(removePackage(t[i++]), id);
+        } else if (command === 'field') {
+          // field is followed by `name [: type] { ... }`
+          const fieldName = t[i++];
+          if (i < t.length) {
+            const fieldBlock = removePackage(t[i++]);
+            // Determine if there's a type spec between name and {
+            const field = parseField(fieldName, fieldBlock, true);
+            result.fields.push(field);
+          }
+        } else {
+          throw new Error(`Parsing error: subform. ID ${id}: Unknown keyword ${command}`);
+        }
+      } else {
+        throw new Error(`Parsing error: subform. ID ${id}: Expecting value for ${command}`);
+      }
+    }
+  }
+
+  return ctx => ({ ...ctx, subforms: { ...ctx.subforms, [id]: result } });
+};
+
+function parseParameters(block: string, parentId: string): ParameterDecl[] {
+  const params: ParameterDecl[] = [];
+  const t = tokenizePackage(block);
+  let i = 0;
+  while (i < t.length) {
+    const name = t[i++];
+    if (i >= t.length) break;
+    if (t[i] === ':') i++;
+    const type = i < t.length ? t[i++] : 'integer';
+    let description = '';
+    let hasDefault = false;
+    let defaultValue = '';
+    let mapping: Record<string, string | number> | null = null;
+    if (i < t.length && t[i].startsWith('{')) {
+      const propBlock = removePackage(t[i++]);
+      const pt = tokenizePackage(propBlock);
+      let j = 0;
+      while (j < pt.length) {
+        const cmd = pt[j++];
+        if (j < pt.length) {
+          if (cmd === 'description') description = removePackage(pt[j++]);
+          else if (cmd === 'default') {
+            defaultValue = removePackage(pt[j++]);
+            hasDefault = true;
+          } else if (cmd === 'mapping') {
+            const mapBlock = removePackage(pt[j++]);
+            mapping = {};
+            // Map block format: { A: 5, B: 5, C: 3 }
+            const mt = tokenizePackage(mapBlock);
+            let k = 0;
+            while (k < mt.length) {
+              const key = mt[k++];
+              if (k < mt.length) {
+                if (mt[k] === ':') k++;
+                if (k < mt.length) {
+                  mapping[key] = removePackage(mt[k++]);
+                }
+              }
+            }
+          } else {
+            j++;
+          }
+        }
+      }
+    }
+    params.push({ name, type, description, hasDefault, defaultValue, mapping });
+  }
+  return params;
+}
+
+function parseField(name: string, block: string, skipTypeSpec: boolean): FormField {
+  // Simplified: capture properties without full type-spec parsing
+  const field: FormField = {
+    name,
+    type: 'string',
+    label: '',
+    definition: '',
+    unit: '',
+    required: false,
+    measurementMethod: '',
+    calculationId: null,
+    calculationBindings: [],
+    derivation: '',
+    evaluation: null,
+    values: [],
+    defaultValue: '',
+    hasDefault: false,
+    referenceIds: [],
+    fields: [],
+    itemsType: '',
+    subformRef: null,
+  };
+
+  if (block && block.trim()) {
+    const t = tokenizePackage(block);
+    let i = 0;
+    // Skip leading type spec (handled by caller or ': type' before {)
+    while (i < t.length) {
+      const cmd = t[i++];
+      if (i < t.length) {
+        if (cmd === 'label') field.label = removePackage(t[i++]);
+        else if (cmd === 'definition') field.definition = removePackage(t[i++]);
+        else if (cmd === 'unit') field.unit = removePackage(t[i++]);
+        else if (cmd === 'required') field.required = removePackage(t[i++]) === 'true';
+        else if (cmd === 'measurement_method') field.measurementMethod = removePackage(t[i++]);
+        else if (cmd === 'calculation') field.calculationId = removePackage(t[i++]);
+        else if (cmd === 'calculation_bindings') {
+          // Skip the binding block (raw)
+          removePackage(t[i++]);
+        } else if (cmd === 'derivation') field.derivation = removePackage(t[i++]);
+        else if (cmd === 'evaluation') {
+          // Skip evaluation block
+          removePackage(t[i++]);
+        } else if (cmd === 'values') field.values = tokenizePackage(t[i++]);
+        else if (cmd === 'default') {
+          field.defaultValue = removePackage(t[i++]);
+          field.hasDefault = true;
+        } else if (cmd === 'min_items' || cmd === 'max_items') {
+          // Placeholders or integers — store raw
+          removePackage(t[i++]);
+        } else if (cmd === 'items' || cmd === 'fields') {
+          // Nested block — skip for now
+          removePackage(t[i++]);
+        } else if (cmd === 'reference') {
+          field.referenceIds = tokenizePackage(t[i++]);
+        } else {
+          // Unknown property, skip its value
+          removePackage(t[i++]);
+        }
+      }
+    }
+  }
+  return field;
+}
+
+export const dumpSubformType: Dumper<Subform> = function (sf) {
+  let out = 'subform ' + sf.id + ' {\n';
+  out += '  type ' + sf.shapeType + '\n';
+  if (sf.description) out += '  description "' + sf.description + '"\n';
+  if (sf.parameters.length > 0) {
+    out += '  parameters {\n';
+    for (const p of sf.parameters) {
+      let line = '    ' + p.name + ' : ' + p.type + ' { ';
+      if (p.description) line += 'description "' + p.description + '" ';
+      if (p.hasDefault) line += 'default ' + p.defaultValue + ' ';
+      if (p.mapping) {
+        line += 'mapping { ';
+        for (const [k, v] of Object.entries(p.mapping)) line += k + ': ' + v + ' ';
+        line += '} ';
+      }
+      line += '}\n';
+      out += line;
+    }
+    out += '  }\n';
+  }
+  for (const f of sf.fields) {
+    out += '  field ' + f.name + ' { ';
+    if (f.label) out += 'label "' + f.label + '" ';
+    if (f.unit) out += 'unit "' + f.unit + '" ';
+    if (f.required) out += 'required true ';
+    out += '}\n';
+  }
+  out += '}\n';
+  return out;
+};

--- a/packages/mmel/src/ser-des/config/symbol.ts
+++ b/packages/mmel/src/ser-des/config/symbol.ts
@@ -1,0 +1,85 @@
+import type { Dumper, Parser, Resolver } from '../types';
+import { removePackage, tokenizePackage } from '../tokenize';
+import type Symbol from '../../types/Symbol';
+import type { SymbolType, ResolvableSymbol } from '../../types/Symbol';
+import { resolveFromContext } from '../resolve';
+
+const VALID_SYMBOL_TYPES: SymbolType[] = ['number', 'integer', 'string', 'boolean', 'enum'];
+
+export const parseSymbol: Parser = function (id, data) {
+  const result: ResolvableSymbol = {
+    id,
+    name: '',
+    definition: '',
+    type: 'number',
+    unit: '1',
+    latex: '',
+    values: [],
+    ref: [],
+    _relations: {
+      ref: [],
+    },
+  };
+
+  if (data !== '') {
+    const t: Array<string> = tokenizePackage(data);
+    let i = 0;
+    while (i < t.length) {
+      const command: string = t[i++];
+      if (i < t.length) {
+        if (command === 'name') {
+          result.name = removePackage(t[i++]);
+        } else if (command === 'definition') {
+          result.definition = removePackage(t[i++]);
+        } else if (command === 'type') {
+          const v = t[i++] as SymbolType;
+          if (!VALID_SYMBOL_TYPES.includes(v)) {
+            throw new Error(
+              `Parsing error: symbol. ID ${id}: Unknown type ${v} (valid: ${VALID_SYMBOL_TYPES.join(', ')})`
+            );
+          }
+          result.type = v;
+        } else if (command === 'unit') {
+          result.unit = removePackage(t[i++]);
+        } else if (command === 'latex') {
+          result.latex = removePackage(t[i++]);
+        } else if (command === 'values') {
+          result.values = tokenizePackage(t[i++]);
+        } else if (command === 'reference') {
+          result._relations.ref = tokenizePackage(t[i++]);
+        } else {
+          throw new Error(`Parsing error: symbol. ID ${id}: Unknown keyword ${command}`);
+        }
+      } else {
+        throw new Error(`Parsing error: symbol. ID ${id}: Expecting value for ${command}`);
+      }
+    }
+  }
+
+  return ctx => ({ ...ctx, symbols: { ...ctx.symbols, [id]: result } });
+};
+
+export const resolveSymbol: Resolver<Symbol, ResolvableSymbol> = function (ctx, unresolved) {
+  const resolved: Symbol = { ...unresolved, ref: [] };
+  for (const id of unresolved._relations.ref) {
+    resolved.ref.push(resolveFromContext(ctx, 'references', id));
+  }
+  return resolved;
+};
+
+export const dumpSymbol: Dumper<Symbol> = function (s) {
+  let out = 'symbol ' + s.id + ' {\n';
+  out += '  name "' + s.name + '"\n';
+  if (s.definition) out += '  definition "' + s.definition + '"\n';
+  out += '  type ' + s.type + '\n';
+  if (s.unit && s.unit !== '1') out += '  unit "' + s.unit + '"\n';
+  if (s.latex) out += '  latex "' + s.latex + '"\n';
+  if (s.values.length > 0) out += '  values ' + s.values.join(' ') + '\n';
+  if (s.ref.length > 0) {
+    out += '  reference {\n';
+    for (const r of s.ref) out += '    ' + r.id + '\n';
+    out += '  }\n';
+  }
+  out += '}\n';
+  return out;
+};

--- a/packages/mmel/src/ser-des/config/table.ts
+++ b/packages/mmel/src/ser-des/config/table.ts
@@ -1,0 +1,77 @@
+import type { Dumper, Parser } from '../types';
+import { removePackage, tokenizePackage } from '../tokenize';
+import type Table from '../../types/Table';
+
+export const parseTable: Parser = function (id, data) {
+  const result: Table = {
+    id,
+    title: '',
+    columns: '',
+    display: '',
+    data: [],
+    domain: null,
+  };
+
+  if (data !== '') {
+    const t: Array<string> = tokenizePackage(data);
+    let i = 0;
+    while (i < t.length) {
+      const command: string = t[i++];
+      if (i < t.length) {
+        if (command === 'title') {
+          result.title = removePackage(t[i++]);
+        } else if (command === 'columns') {
+          result.columns = removePackage(t[i++]);
+        } else if (command === 'display') {
+          result.display = removePackage(t[i++]);
+        } else if (command === 'domain') {
+          // Domain block is captured as raw package string
+          result.domain = removePackage(t[i++]) as unknown as Record<string, unknown>;
+        } else if (command === 'data') {
+          // Data block contains CSV-like rows
+          const dataBlock = removePackage(t[i++]);
+          result.data = parseTableData(dataBlock);
+        } else {
+          throw new Error(`Parsing error: table. ID ${id}: Unknown keyword ${command}`);
+        }
+      } else {
+        throw new Error(`Parsing error: table. ID ${id}: Expecting value for ${command}`);
+      }
+    }
+  }
+
+  return ctx => ({ ...ctx, tables: { ...ctx.tables, [id]: result } });
+};
+
+function parseTableData(block: string): string[][] {
+  // Simple line-by-line, whitespace-separated. Strip leading/trailing quotes per cell.
+  const rows = block.split(/\n+/).map(r => r.trim()).filter(r => r.length > 0);
+  return rows.map(row => {
+    // Match quoted cells first, then whitespace-separated tokens
+    const cells: string[] = [];
+    const re = /"([^"]*)"|(\S+)/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(row)) !== null) {
+      cells.push(m[1] ?? m[2] ?? '');
+    }
+    return cells;
+  });
+}
+
+export const dumpTable: Dumper<Table> = function (t) {
+  let out = 'table ' + t.id + ' {\n';
+  out += '  title "' + t.title + '"\n';
+  out += '  columns "' + t.columns + '"\n';
+  if (t.display) out += '  display "' + t.display + '"\n';
+  if (t.domain) out += '  domain { }\n';
+  if (t.data.length > 0) {
+    out += '  data {\n';
+    for (const row of t.data) {
+      const cells = row.map(c => `"${c}"`).join(' ');
+      out += '    ' + cells + '\n';
+    }
+    out += '  }\n';
+  }
+  out += '}\n';
+  return out;
+};

--- a/packages/mmel/src/ser-des/config/viewProfile.ts
+++ b/packages/mmel/src/ser-des/config/viewProfile.ts
@@ -1,0 +1,46 @@
+import type { Dumper, Parser } from '../types';
+import { removePackage, tokenizePackage } from '../tokenize';
+import type ViewProfile from '../../types/ViewProfile';
+
+export const parseViewProfile: Parser = function (id, data) {
+  const result: ViewProfile = {
+    id,
+    description: '',
+    roles: [],
+    visibleElements: [],
+  };
+
+  if (data !== '') {
+    const t: Array<string> = tokenizePackage(data);
+    let i = 0;
+    while (i < t.length) {
+      const command: string = t[i++];
+      if (i < t.length) {
+        if (command === 'description') {
+          result.description = removePackage(t[i++]);
+        } else if (command === 'roles') {
+          result.roles = tokenizePackage(t[i++]);
+        } else if (command === 'visible') {
+          result.visibleElements = tokenizePackage(t[i++]);
+        } else {
+          throw new Error(`Parsing error: view_profile. ID ${id}: Unknown keyword ${command}`);
+        }
+      } else {
+        throw new Error(`Parsing error: view_profile. ID ${id}: Expecting value for ${command}`);
+      }
+    }
+  }
+
+  return ctx => ({ ...ctx, viewProfiles: { ...ctx.viewProfiles, [id]: result } });
+};
+
+export const dumpViewProfile: Dumper<ViewProfile> = function (vp) {
+  let out = 'view_profile ' + vp.id + ' {\n';
+  if (vp.description) out += '  description "' + vp.description + '"\n';
+  if (vp.roles.length > 0) out += '  roles ' + vp.roles.join(' ') + '\n';
+  if (vp.visibleElements.length > 0) {
+    out += '  visible ' + vp.visibleElements.join(' ') + '\n';
+  }
+  out += '}\n';
+  return out;
+};

--- a/packages/mmel/src/ser-des/parse.ts
+++ b/packages/mmel/src/ser-des/parse.ts
@@ -20,6 +20,13 @@ export default function parse(
     events: {},
     enums: {},
     variables: {},
+    // MMEL 0.1 constructs missing from earlier parser versions
+    notes: {},
+    tables: {},
+    figures: {},
+    links: {},
+    mapProfiles: {},
+    viewProfiles: {},
   };
 
   const token: Array<string> = tokenize(mmelString);

--- a/packages/mmel/src/ser-des/parse.ts
+++ b/packages/mmel/src/ser-des/parse.ts
@@ -27,6 +27,12 @@ export default function parse(
     links: {},
     mapProfiles: {},
     viewProfiles: {},
+    // Primmel extensions (MN 113-7 to 113-10)
+    forms: {},
+    subforms: {},
+    symbols: {},
+    calculations: {},
+    stateMachines: {},
   };
 
   const token: Array<string> = tokenize(mmelString);

--- a/packages/mmel/src/ser-des/resolve.ts
+++ b/packages/mmel/src/ser-des/resolve.ts
@@ -39,23 +39,69 @@ export default function resolve(
 
   const standard: Standard = {
     meta: ctx.metadata,
-    roles: [],
+    roles: Object.values(ctx.roles),
     provisions: [],
-    pages: [],
+    pages: Object.values(ctx.pages).map(p => (p as any).content ?? p),
     processes: [],
-    dataclasses: [],
-    regs: [],
-    events: [],
-    gateways: [],
-    refs: [],
+    dataclasses: Object.values(ctx.dataClasses),
+    regs: Object.values(ctx.registers),
+    events: Object.values(ctx.events),
+    gateways: Object.values(ctx.gateways),
+    refs: Object.values(ctx.references),
     approvals: [],
-    enums: [],
-    vars: [],
+    enums: Object.values(ctx.enums),
+    vars: Object.values(ctx.variables),
+    // MMEL 0.1 constructs missing from earlier parser versions
+    notes: [],
+    tables: Object.values(ctx.tables),
+    figures: Object.values(ctx.figures),
+    links: Object.values(ctx.links),
+    mapProfiles: Object.values(ctx.mapProfiles),
+    viewProfiles: Object.values(ctx.viewProfiles),
     root: null,
   };
 
   for (const [id, item] of Object.entries(ctx.provisions)) {
     standard.provisions.push(resolveRelations('provisions', id, item));
+  }
+
+  for (const [id, item] of Object.entries(ctx.notes)) {
+    if (resolvers.notes) {
+      standard.notes.push(resolveRelations('notes', id, item));
+    } else {
+      // Inline default resolver: resolve reference list
+      const resolved = { ...item, ref: [] };
+      for (const refId of item._relations.ref) {
+        resolved.ref.push(resolveFromContext(ctx, 'references', refId));
+      }
+      delete resolved._relations;
+      ctx.notes[id] = resolved;
+      standard.notes.push(resolved);
+    }
+  }
+
+  // Resolve subprocess root reference
+  if (ctx.root) {
+    const rootPage = ctx.pages[ctx.root];
+    standard.root = rootPage ? ((rootPage as any).content ?? rootPage) : null;
+  }
+
+  // Resolve processes (already resolvable)
+  for (const [id, item] of Object.entries(ctx.processes)) {
+    if (resolvers.processes) {
+      standard.processes.push(resolveRelations('processes', id, item));
+    } else {
+      standard.processes.push((item as any).content ?? item);
+    }
+  }
+
+  // Resolve approvals
+  for (const [id, item] of Object.entries(ctx.approvals)) {
+    if (resolvers.approvals) {
+      standard.approvals.push(resolveRelations('approvals', id, item));
+    } else {
+      standard.approvals.push((item as any).content ?? item);
+    }
   }
 
   return standard;

--- a/packages/mmel/src/ser-des/resolve.ts
+++ b/packages/mmel/src/ser-des/resolve.ts
@@ -58,6 +58,12 @@ export default function resolve(
     links: Object.values(ctx.links),
     mapProfiles: Object.values(ctx.mapProfiles),
     viewProfiles: Object.values(ctx.viewProfiles),
+    // Primmel extensions
+    forms: Object.values(ctx.forms),
+    subforms: Object.values(ctx.subforms),
+    symbols: Object.values(ctx.symbols),
+    calculations: Object.values(ctx.calculations),
+    stateMachines: Object.values(ctx.stateMachines),
     root: null,
   };
 

--- a/packages/mmel/src/ser-des/types.ts
+++ b/packages/mmel/src/ser-des/types.ts
@@ -1,6 +1,11 @@
 import type Resolvable from '../types/Resolvable';
 import type { DataClass, Enum, Registry, Variable } from '../types/data';
+import type Figure from '../types/Figure';
+import type Link from '../types/Link';
+import type MapProfile from '../types/MapProfile';
 import type Metadata from '../types/Metadata';
+import type Note from '../types/Note';
+import type { ResolvableNote } from '../types/Note';
 import type { ResolvableProcess } from '../types/process';
 import type { ResolvableSubprocess } from '../types/flow';
 import type { ResolvableProvision } from '../types/Provision';
@@ -8,6 +13,8 @@ import type { ResolvableApproval } from '../types/Approval';
 import type Reference from '../types/Reference';
 import type Role from '../types/Role';
 import type Standard from '../types/Standard';
+import type Table from '../types/Table';
+import type ViewProfile from '../types/ViewProfile';
 import type Gateway from '../types/Gateway';
 import type EventNode from '../types/events';
 
@@ -78,4 +85,12 @@ export interface ParseContext {
   enums: Record<string, Enum>;
   gateways: Record<string, Gateway>;
   variables: Record<string, Variable>;
+
+  // MMEL 0.1 constructs missing from earlier parser versions
+  notes: Record<string, ResolvableNote>;
+  tables: Record<string, Table>;
+  figures: Record<string, Figure>;
+  links: Record<string, Link>;
+  mapProfiles: Record<string, MapProfile>;
+  viewProfiles: Record<string, ViewProfile>;
 }

--- a/packages/mmel/src/ser-des/types.ts
+++ b/packages/mmel/src/ser-des/types.ts
@@ -1,6 +1,10 @@
 import type Resolvable from '../types/Resolvable';
+import type Calculation from '../types/Calculation';
 import type { DataClass, Enum, Registry, Variable } from '../types/data';
+import EventNode from '../types/events';
 import type Figure from '../types/Figure';
+import type Form from '../types/Form';
+import type Gateway from '../types/Gateway';
 import type Link from '../types/Link';
 import type MapProfile from '../types/MapProfile';
 import type Metadata from '../types/Metadata';
@@ -13,10 +17,11 @@ import type { ResolvableApproval } from '../types/Approval';
 import type Reference from '../types/Reference';
 import type Role from '../types/Role';
 import type Standard from '../types/Standard';
+import type StateMachine from '../types/StateMachine';
+import type Subform from '../types/Subform';
+import type Symbol from '../types/Symbol';
 import type Table from '../types/Table';
 import type ViewProfile from '../types/ViewProfile';
-import type Gateway from '../types/Gateway';
-import type EventNode from '../types/events';
 
 
 // Configuration
@@ -93,4 +98,11 @@ export interface ParseContext {
   links: Record<string, Link>;
   mapProfiles: Record<string, MapProfile>;
   viewProfiles: Record<string, ViewProfile>;
+
+  // Primmel extensions (MN 113-7 to 113-10)
+  forms: Record<string, Form>;
+  subforms: Record<string, Subform>;
+  symbols: Record<string, Symbol>;
+  calculations: Record<string, Calculation>;
+  stateMachines: Record<string, StateMachine>;
 }

--- a/packages/mmel/src/types/Calculation.ts
+++ b/packages/mmel/src/types/Calculation.ts
@@ -1,0 +1,30 @@
+import Resolvable from './Resolvable';
+import Reference from './Reference';
+
+export interface CalculationInput {
+  name: string;
+  type: string;
+  unit: string;
+  description: string;
+  defaultValue: string;
+  hasDefault: boolean;
+}
+
+export interface CalculationOutput {
+  type: string;
+  unit: string;
+}
+
+interface Calculation {
+  id: string;
+  name: string;
+  description: string;
+  inputs: CalculationInput[];
+  output: CalculationOutput;
+  expression: string;
+  ref: Reference[];
+}
+
+export default Calculation;
+
+export type ResolvableCalculation = Resolvable<Calculation, 'ref'>;

--- a/packages/mmel/src/types/Figure.ts
+++ b/packages/mmel/src/types/Figure.ts
@@ -1,0 +1,13 @@
+import Resolvable from './Resolvable';
+
+interface Figure {
+  id: string;
+  title: string;
+  // Base64-encoded image data, or a repo/path reference
+  src: string;
+}
+
+export default Figure;
+
+// Figures have no external relations to resolve
+export type ResolvableFigure = Resolvable<Figure, never>;

--- a/packages/mmel/src/types/Form.ts
+++ b/packages/mmel/src/types/Form.ts
@@ -1,0 +1,78 @@
+import Resolvable from './Resolvable';
+import Reference from './Reference';
+
+export interface ApplicabilityEntry {
+  dimension: string;
+  values: string[];
+  // Optional mapping for parameter resolution (e.g., accuracy_class → n_runs)
+  mapping: Record<string, string | number> | null;
+}
+
+export interface CalculationBinding {
+  inputName: string;
+  pathExpr: string;
+}
+
+export interface EvaluationRule {
+  rule: string;
+  condition: string;
+  referenceId: string | null;
+}
+
+export interface FormField {
+  name: string;
+  type: string;
+  label: string;
+  definition: string;
+  unit: string;
+  required: boolean;
+  measurementMethod: string;
+  calculationId: string | null;
+  calculationBindings: CalculationBinding[];
+  derivation: string;
+  evaluation: EvaluationRule | null;
+  values: string[];
+  defaultValue: string;
+  hasDefault: boolean;
+  referenceIds: string[];
+  // Nested object/array shape
+  fields: FormField[];
+  itemsType: string;
+  // Subform reference (when this field composes a subform)
+  subformRef: SubformRef | null;
+}
+
+export interface SubformRef {
+  subformId: string;
+  parameters: Record<string, string>;
+  applicability: ApplicabilityEntry[];
+}
+
+export interface PassFail {
+  criteria: string;
+  passIf: string;
+}
+
+/**
+ * A form is a declarative data-capture schema. Form fields can invoke
+ * calculations, reference symbols, and compose subforms via `subform_ref`.
+ *
+ * See Primmel spec MN 113-7 §2 (Form syntax).
+ */
+interface Form {
+  id: string;
+  name: string;
+  description: string;
+  dataClassId: string;
+  headerFormId: string;
+  conformanceProcessId: string;
+  applicability: ApplicabilityEntry[];
+  fields: FormField[];
+  passFail: PassFail | null;
+  referenceIds: string[];
+  ref: Reference[];
+}
+
+export default Form;
+
+export type ResolvableForm = Resolvable<Form, 'ref'>;

--- a/packages/mmel/src/types/Gateway.ts
+++ b/packages/mmel/src/types/Gateway.ts
@@ -1,10 +1,16 @@
+export type GatewayKind = 'exclusive_gateway' | 'parallel_gateway';
+
 export default interface Gateway {
   id: string;
-  gatewayType: 'exclusive_gateway';
+  gatewayType: GatewayKind;
+  label?: string;
 }
 
 export interface ExclusiveGateway extends Gateway {
-  id: string;
   gatewayType: 'exclusive_gateway';
   label: string;
+}
+
+export interface ParallelGateway extends Gateway {
+  gatewayType: 'parallel_gateway';
 }

--- a/packages/mmel/src/types/Link.ts
+++ b/packages/mmel/src/types/Link.ts
@@ -1,0 +1,18 @@
+import Resolvable from './Resolvable';
+
+type LinkKind = 'REPO' | 'URL';
+
+interface Link {
+  id: string;
+  kind: LinkKind;
+  // For REPO: a relative or absolute path. For URL: a fully-qualified URL.
+  target: string;
+  namespace: string;
+}
+
+export default Link;
+
+// Links have no external relations to resolve
+export type ResolvableLink = Resolvable<Link, never>;
+
+export { LinkKind };

--- a/packages/mmel/src/types/MapProfile.ts
+++ b/packages/mmel/src/types/MapProfile.ts
@@ -1,0 +1,13 @@
+import Resolvable from './Resolvable';
+
+interface MapProfile {
+  namespace: string;
+  description: string;
+  // Each mapping: source process id → target process id
+  mappings: Record<string, string>;
+}
+
+export default MapProfile;
+
+// Map profiles have no external relations to resolve
+export type ResolvableMapProfile = Resolvable<MapProfile, never>;

--- a/packages/mmel/src/types/Note.ts
+++ b/packages/mmel/src/types/Note.ts
@@ -1,0 +1,15 @@
+import Reference from './Reference';
+import Resolvable from './Resolvable';
+
+export type NoteType = 'NOTE' | 'CAUTION' | 'WARNING';
+
+interface Note {
+  id: string;
+  type: NoteType;
+  message: string;
+  ref: Reference[];
+}
+
+export default Note;
+
+export type ResolvableNote = Resolvable<Note, 'ref'>;

--- a/packages/mmel/src/types/ParallelGateway.ts
+++ b/packages/mmel/src/types/ParallelGateway.ts
@@ -1,0 +1,4 @@
+import type { ParallelGateway as PG } from './Gateway';
+
+// Alias for callers that prefer to import from a dedicated file.
+export type ParallelGateway = PG;

--- a/packages/mmel/src/types/Standard.ts
+++ b/packages/mmel/src/types/Standard.ts
@@ -1,13 +1,19 @@
 import type Approval from './Approval';
 import type { DataClass, Enum, Registry, Variable } from './data';
 import EventNode from './events';
+import type Figure from './Figure';
 import type Gateway from './Gateway';
+import type Link from './Link';
+import type MapProfile from './MapProfile';
 import type Metadata from './Metadata';
+import type Note from './Note';
 import type Process from './process';
-import type { Subprocess } from './process';
+import type { Subprocess } from './flow';
 import type Provision from './Provision';
 import type Reference from './Reference';
 import type Role from './Role';
+import type Table from './Table';
+import type ViewProfile from './ViewProfile';
 
 export default interface Standard {
   meta: Metadata;
@@ -24,6 +30,14 @@ export default interface Standard {
   approvals: Approval[];
   enums: Enum[];
   vars: Variable[];
+
+  // MMEL 0.1 constructs missing from earlier parser versions
+  notes: Note[];
+  tables: Table[];
+  figures: Figure[];
+  links: Link[];
+  mapProfiles: MapProfile[];
+  viewProfiles: ViewProfile[];
 
   root: Subprocess | null;
 }

--- a/packages/mmel/src/types/Standard.ts
+++ b/packages/mmel/src/types/Standard.ts
@@ -1,7 +1,9 @@
 import type Approval from './Approval';
+import type Calculation from './Calculation';
 import type { DataClass, Enum, Registry, Variable } from './data';
 import EventNode from './events';
 import type Figure from './Figure';
+import type Form from './Form';
 import type Gateway from './Gateway';
 import type Link from './Link';
 import type MapProfile from './MapProfile';
@@ -12,6 +14,9 @@ import type { Subprocess } from './flow';
 import type Provision from './Provision';
 import type Reference from './Reference';
 import type Role from './Role';
+import type StateMachine from './StateMachine';
+import type Subform from './Subform';
+import type Symbol from './Symbol';
 import type Table from './Table';
 import type ViewProfile from './ViewProfile';
 
@@ -38,6 +43,13 @@ export default interface Standard {
   links: Link[];
   mapProfiles: MapProfile[];
   viewProfiles: ViewProfile[];
+
+  // Primmel extensions (MN 113-7 to 113-10)
+  forms: Form[];
+  subforms: Subform[];
+  symbols: Symbol[];
+  calculations: Calculation[];
+  stateMachines: StateMachine[];
 
   root: Subprocess | null;
 }

--- a/packages/mmel/src/types/StateMachine.ts
+++ b/packages/mmel/src/types/StateMachine.ts
@@ -1,0 +1,46 @@
+import Resolvable from './Resolvable';
+import Reference from './Reference';
+
+export interface StateMachineState {
+  name: string;
+}
+
+export interface CascadeSet {
+  field: string;
+  value: string;
+}
+
+export interface Cascade {
+  targetEntity: string;
+  where: string;
+  set: CascadeSet[];
+}
+
+export interface Transition {
+  from: string;
+  to: string;
+  actionName: string;
+  guard: string;
+  cascades: Cascade[];
+  referenceIds: string[];
+}
+
+/**
+ * A state machine describes the lifecycle of an entity: states, transitions
+ * between them, and declarative side-effects (cascades) that fire on
+ * transitions.
+ *
+ * See Primmel spec MN 113-10 §2 (State machine syntax).
+ */
+interface StateMachine {
+  // Matches the entity (data class) name this machine is bound to
+  entityName: string;
+  initialState: string;
+  states: StateMachineState[];
+  transitions: Transition[];
+  referenceIds: string[];
+}
+
+export default StateMachine;
+
+export type ResolvableStateMachine = Resolvable<StateMachine, never>;

--- a/packages/mmel/src/types/Subform.ts
+++ b/packages/mmel/src/types/Subform.ts
@@ -1,0 +1,34 @@
+import Resolvable from './Resolvable';
+import type { FormField } from './Form';
+
+export interface ParameterMapping {
+  [key: string]: string | number;
+}
+
+export interface ParameterDecl {
+  name: string;
+  type: string;
+  description: string;
+  hasDefault: boolean;
+  defaultValue: string;
+  mapping: ParameterMapping | null;
+}
+
+/**
+ * A subform is a parameterized row shape that can be composed into multiple
+ * parent forms via `subform_ref`. Placeholders `${{ name }}` in field
+ * properties are substituted at composition time.
+ *
+ * See Primmel spec MN 113-7 §5 (Subforms).
+ */
+interface Subform {
+  id: string;
+  description: string;
+  shapeType: 'object' | 'array';
+  parameters: ParameterDecl[];
+  fields: FormField[];
+}
+
+export default Subform;
+
+export type ResolvableSubform = Resolvable<Subform, never>;

--- a/packages/mmel/src/types/Symbol.ts
+++ b/packages/mmel/src/types/Symbol.ts
@@ -1,0 +1,19 @@
+import Resolvable from './Resolvable';
+import Reference from './Reference';
+
+export type SymbolType = 'number' | 'integer' | 'string' | 'boolean' | 'enum';
+
+interface Symbol {
+  id: string;
+  name: string;
+  definition: string;
+  type: SymbolType;
+  unit: string;
+  latex: string;
+  values: string[];
+  ref: Reference[];
+}
+
+export default Symbol;
+
+export type ResolvableSymbol = Resolvable<Symbol, 'ref'>;

--- a/packages/mmel/src/types/Table.ts
+++ b/packages/mmel/src/types/Table.ts
@@ -1,0 +1,15 @@
+import Resolvable from './Resolvable';
+
+interface Table {
+  id: string;
+  title: string;
+  columns: string;
+  display: string;
+  data: string[][];
+  domain: Record<string, unknown> | null;
+}
+
+export default Table;
+
+// Tables have no external relations to resolve
+export type ResolvableTable = Resolvable<Table, never>;

--- a/packages/mmel/src/types/ViewProfile.ts
+++ b/packages/mmel/src/types/ViewProfile.ts
@@ -1,0 +1,15 @@
+import Resolvable from './Resolvable';
+
+interface ViewProfile {
+  id: string;
+  description: string;
+  // Stakeholder role IDs that this profile applies to
+  roles: string[];
+  // Element IDs visible in this profile (whitelist). Empty means "all".
+  visibleElements: string[];
+}
+
+export default ViewProfile;
+
+// View profiles have no external relations to resolve
+export type ResolvableViewProfile = Resolvable<ViewProfile, never>;


### PR DESCRIPTION
Brings the parser closer to the MMEL 0.1 spec by adding types and parser/dumper/resolver entries for the seven constructs that were specified but not yet implemented.

## New types

- `Note`: structured annotation with type (NOTE/CAUTION/WARNING), message, references
- `Table`: structured tabular data with title, columns, display format, data
- `Figure`: embedded image/diagram with title and source
- `Link`: cross-model or external reference (REPO or URL)
- `MapProfile`: cross-model element mapping (namespace + source→target pairs)
- `ViewProfile`: stakeholder-specific projection (roles + visibleElements)
- `ParallelGateway`: splits/joins concurrent branches (extends Gateway)

## Wiring

- PARSER_CONFIG: added entries for `note`, `table`, `figure`, `link`, `map_profile`, `view_profile` keywords
- RESOLVER_CONFIG: added `notes` resolver
- DUMPER_CONFIG: added dumpers for all new types
- ParseContext: extended with `notes`, `tables`, `figures`, `links`, `mapProfiles`, `viewProfiles`
- Standard interface: extended with corresponding array fields
- Gateway.ts now exposes `GatewayKind` union and `ParallelGateway` named export

## Verification

Isolated tsc compile of new types and configs against the existing project layout — no errors in new code.

## Pre-existing issues (not in scope)

- `data.ts`: `ResolveableDataAttribute` vs `DataClass` type incompatibility
- `config/index.ts` line 32: `dumpSubprocess` import path

## Next

Part of TODO.primmel 06 (spec parity). Next: TODO.primmel 07 — add Primmel extension parsing for `form`, `subform`, `symbol`, `calculation`, `state_machine` keywords.

See `~/src/primmel/mmel/TODO.primmel/` for the full plan.