### PR TITLE
Rename package: @riboseinc/mmel → @primmel/mmel (v1.0.0)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,121 @@
+# Migration: `@riboseinc/mmel` → `@primmel/mmel`
+
+**Date:** 2026-07-03
+**Status:** READY — package renamed; npm publish + GitHub transfer pending
+
+## Summary
+
+The `mmel` package is being renamed and rebranded:
+
+| Before | After |
+|---|---|
+| npm: `@riboseinc/mmel` | npm: `@primmel/mmel` |
+| GitHub: `github.com/metanorma/mmel-ts` | GitHub: `github.com/primmel/mmel` |
+| Brand: "MMEL tools" | Brand: "Primmel — TypeScript tools" |
+| Version: `0.1.0` | Version: `1.0.0` (Primmel is a new major version) |
+
+## Why
+
+Primmel is the **successor** to MMEL. The TypeScript package now
+supports the five Primmel extensions (`form`, `subform`, `symbol`,
+`calculation`, `state_machine`) in addition to all MMEL 0.1 constructs.
+
+The rename aligns the package identity with the language identity.
+
+## What changed in the package
+
+### `package.json` updates
+
+- `name`: `@riboseinc/mmel` → `@primmel/mmel`
+- `version`: `0.1.0` → `1.0.0` (major version bump — Primmel is a new generation)
+- `description`: added
+- `repository`: `github.com/metanorma/mmel-ts` → `github.com/primmel/mmel`
+- `homepage`: added
+- `bugs`: added
+- `keywords`: added (`primmel`, `mmel`, `compliance`, `ocl`, etc.)
+- `publishConfig`: `access: public` (the `@primmel` scope is public)
+- `contributors`: Ribose Inc. retained as contributor
+
+### README updates
+
+- Root README rewritten with Primmel branding, usage example, migration section
+- Package README rewritten with full exports list + Primmel extensions table
+
+### No code changes
+
+The TypeScript source is unchanged. Imports within the package use
+relative paths, not the package name. Existing consumers' imports work
+without modification (only the package name in their `package.json` needs
+updating).
+
+## Migration for consumers
+
+### Step 1 — Update package.json
+
+```sh
+npm uninstall @riboseinc/mmel
+npm install @primmel/mmel
+```
+
+Or with yarn:
+
+```sh
+yarn remove @riboseinc/mmel
+yarn add @primmel/mmel
+```
+
+### Step 2 — Update imports (no change needed)
+
+The import paths are identical:
+
+```ts
+// Before
+import { load, dump } from '@riboseinc/mmel'
+
+// After
+import { load, dump } from '@primmel/mmel'
+```
+
+### Step 3 — Verify
+
+The new package supports everything from `@riboseinc/mmel@latest` plus
+the five Primmel extension keywords. Existing code works unchanged.
+
+## What's NOT in this commit (requires admin access)
+
+- **GitHub repo transfer**: `github.com/metanorma/mmel-ts` → `github.com/primmel/mmel`
+  - Requires owner permission on both source and target orgs
+  - GitHub will redirect automatically after transfer
+- **npm publish**: `npm publish` of `@primmel/mmel@1.0.0`
+  - Requires `@primmel` scope ownership on npm
+  - The `@primmel` scope must be created first
+
+## Steps to complete the rename (after this PR merges)
+
+1. **GitHub repo transfer**
+   - Go to `github.com/metanorma/mmel-ts/settings`
+   - "Danger Zone" → "Transfer"
+   - Transfer to `primmel` org, new name `mmel`
+   - Verify redirect from old URL works
+
+2. **npm publish**
+   - Create `@primmel` scope on npm (owner: primmel project)
+   - `npm login` with appropriate credentials
+   - From the mmel-ts repo: `cd packages/mmel && npm publish`
+   - Verify `npm view @primmel/mmel`
+
+3. **Sunset `@riboseinc/mmel`**
+   - Publish a final version of `@riboseinc/mmel` that is a stub
+     pointing to `@primmel/mmel`
+   - Mark `@riboseinc/mmel` as deprecated on npm
+
+4. **Update dependent repos**
+   - `oimlsmart/smart` — replace `@riboseinc/mmel` with `@primmel/mmel`
+     in `package.json` (currently the converter uses structural typing,
+     so no import changes needed)
+
+## Verification
+
+- Code compiles cleanly via `tsc --noEmit`
+- All existing types and parser/dumper/resolver entries work unchanged
+- README correctly points to the new GitHub and npm locations

--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,62 @@
-= MMEL tools
+= Primmel — TypeScript tools
 
-For `mmel` package docs, see `packages/mmel`.
+Parser, types, and serializer/deserializer for the
+https://github.com/primmel/spec[Primmel] modelling language (formerly MMEL).
+
+== Packages
+
+* `@primmel/mmel` (in `packages/mmel/`) — types and ser/des
+
+== Usage
+
+[source,ts]
+----
+import { load, dump } from '@primmel/mmel'
+
+// Parse a .mmel file
+const standard = load(mmelString)
+
+// Serialize back to a .mmel string
+const out = dump(standard)
+----
+
+== What is Primmel?
+
+Primmel is the second generation of MMEL — a Domain-Sefined Language for
+integrated compliance modelling. See the spec at
+https://github.com/primmel/spec.
+
+Primmel supports all MMEL 0.1 constructs plus five extensions:
+
+* `form` / `subform` — declarative data-capture schemas with parameterized composition
+* `symbol` — typed, unit-aware symbol registry
+* `calculation` — named OCL computation primitives
+* `state_machine` — entity lifecycles with declarative cascades
+
+== Migration from `@riboseinc/mmel`
+
+If you previously used `@riboseinc/mmel`, replace:
+
+[source,sh]
+----
+npm uninstall @riboseinc/mmel
+npm install @primmel/mmel
+----
+
+Imports are identical:
+
+[source,ts]
+----
+// before
+import { load } from '@riboseinc/mmel'
+
+// after
+import { load } from '@primmel/mmel'
+----
+
+The package is API-compatible with the latest `@riboseinc/mmel` plus
+support for the five Primmel extension keywords.
+
+== Development
 
 Please run `yarn lint` (and `yarn lint-fix` if necessary) after your changes.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mmel-monorepo",
+  "name": "primmel-monorepo",
   "private": true,
   "workspaces": [
     "packages/*"
@@ -17,5 +17,11 @@
     "prepare": "yarn run compile",
     "pretest": "yarn run compile",
     "posttest": "yarn run lint"
+  },
+  "description": "Primmel monorepo \u2014 TypeScript tools for the Primmel modelling language (formerly MMEL)",
+  "repository": "https://github.com/primmel/mmel",
+  "homepage": "https://github.com/primmel/mmel",
+  "bugs": {
+    "url": "https://github.com/primmel/mmel/issues"
   }
 }

--- a/packages/mmel/README.adoc
+++ b/packages/mmel/README.adoc
@@ -1,3 +1,52 @@
-= MMEL tools for TypeScript
+= @primmel/mmel — TypeScript tools
 
-Includes interfaces and basic serialization/deserialization functionality.
+Parser, types, and serializer/deserializer for the
+https://github.com/primmel/spec[Primmel] modelling language (formerly MMEL).
+
+== Exports
+
+* `load(mmelString: string): Standard` — parse a .mmel file into a typed Standard
+* `dump(standard: Standard): string` — serialize a Standard back to .mmel syntax
+* Types: `Standard`, `Process`, `DataClass`, `Registry`, `Event`, `Gateway`,
+  `Approval`, `Provision`, `Reference`, `Role`, `Variable`, `Enum`, plus
+  Primmel extensions: `Form`, `Subform`, `Symbol`, `Calculation`, `StateMachine`
+
+== Usage
+
+[source,ts]
+----
+import { load, dump } from '@primmel/mmel'
+
+const standard = load(mmelString)
+// ...
+const out = dump(standard)
+----
+
+== Primmel extensions
+
+This package supports all MMEL 0.1 keywords plus five extensions
+defined in the Primmel spec:
+
+[cols="1,2"]
+|===
+|Keyword |Purpose
+
+|`form`
+|Declarative data-capture form schema
+
+|`subform`
+|Reusable parameterized row shape
+
+|`symbol`
+|Typed, unit-aware formal symbol
+
+|`calculation`
+|Named OCL computation primitive
+
+|`state_machine`
+|Entity lifecycle with declarative cascades
+
+|===
+
+See the https://github.com/primmel/spec/tree/main/sources[spec sources]
+for the full language reference.

--- a/packages/mmel/package.json
+++ b/packages/mmel/package.json
@@ -1,9 +1,17 @@
 {
-  "name": "@riboseinc/mmel",
-  "version": "0.1.0",
+  "name": "@primmel/mmel",
+  "version": "1.0.0",
+  "description": "Primmel (formerly MMEL) — parser, types, and serializer for the Primmel modelling language",
   "main": "index.js",
-  "repository": "https://github.com/metanorma/mmel-ts",
-  "author": "Ribose Inc. <open.source@ribose.com>",
+  "repository": "https://github.com/primmel/mmel",
+  "homepage": "https://github.com/primmel/mmel",
+  "bugs": {
+    "url": "https://github.com/primmel/mmel/issues"
+  },
+  "author": "Primmel project <primmel@ribose.com>",
+  "contributors": [
+    "Ribose Inc. <open.source@ribose.com>"
+  ],
   "scripts": {},
   "files": [
     "*.js",
@@ -13,5 +21,18 @@
     "**/*.js.map",
     "**/*.d.ts"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "keywords": [
+    "primmel",
+    "mmel",
+    "multi-modal",
+    "modelling",
+    "compliance",
+    "standard",
+    "ocl",
+    "metanorma"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
 }


### PR DESCRIPTION
Aligns the package identity with the language identity. Primmel is the successor to MMEL; the TypeScript package now supports the five Primmel extensions (form, subform, symbol, calculation, state_machine) plus all MMEL 0.1 constructs.

## Changes

- `packages/mmel/package.json`: renamed to `@primmel/mmel`, bumped to 1.0.0, repository → `github.com/primmel/mmel`
- `package.json` (root): renamed monorepo to `primmel-monorepo`
- `README.adoc` (root): rewritten with Primmel branding + migration section
- `packages/mmel/README.adoc`: rewritten with exports list + extensions table
- `MIGRATION.md` (new): detailed consumer migration + admin steps

## No code changes

The TypeScript source uses relative imports only. Existing consumers' imports work without modification after they update their `package.json` dependency.

## Admin steps required (out of scope for this PR)

1. **GitHub repo transfer**: `metanorma/mmel-ts` → `primmel/mmel`
2. **npm publish**: `npm publish @primmel/mmel@1.0.0` (requires `@primmel` scope)
3. **Sunset @riboseinc/mmel**: publish final stub that points to `@primmel/mmel`, mark deprecated

See `MIGRATION.md` for the full checklist.

## Related

- Primmel spec: https://github.com/primmel/spec/pull/3 (merged) — defines the five extensions this package supports
- Prior PR: https://github.com/metanorma/mmel-ts/pull/2 (merged) — spec parity + Primmel parser keywords