### PR TITLE
Fix critical tokenizer bug: string-aware brace counting + event keywords

### DIFF
--- a/packages/mmel/src/ser-des/config/index.ts
+++ b/packages/mmel/src/ser-des/config/index.ts
@@ -99,24 +99,15 @@ export const PARSER_CONFIG: ParserConfiguration = {
     parse: parseExclusiveGate,
   },
 
-  start: {
-    takesID: true,
-    parse: parseStartEvent,
-  },
-
-  end: {
-    takesID: true,
-    parse: parseEndEvent,
-  },
-
-  signalcatch: {
-    takesID: true,
-    parse: parseSignalCatchEvent,
-  },
-  timer: {
-    takesID: true,
-    parse: parseTimerEvent,
-  },
+  // Events: support both short (start/end) and full (start_event/end_event) forms
+  start: { takesID: true, parse: parseStartEvent },
+  end: { takesID: true, parse: parseEndEvent },
+  start_event: { takesID: true, parse: parseStartEvent },
+  end_event: { takesID: true, parse: parseEndEvent },
+  signalcatch: { takesID: true, parse: parseSignalCatchEvent },
+  signal_catch_event: { takesID: true, parse: parseSignalCatchEvent },
+  timer: { takesID: true, parse: parseTimerEvent },
+  timer_event: { takesID: true, parse: parseTimerEvent },
 
   reference: {
     takesID: true,

--- a/packages/mmel/src/ser-des/tokenize.ts
+++ b/packages/mmel/src/ser-des/tokenize.ts
@@ -25,6 +25,18 @@ export default function tokenize(x: string): string[] {
         let count = 1;
         while (i < x.length && count > 0) {
           char = x.charAt(i);
+          // Skip string content: don't count braces inside quoted strings
+          if (char === '"') {
+            t += char;
+            i++;
+            while (i < x.length && x.charAt(i) !== '"') {
+              t += x.charAt(i);
+              i++;
+            }
+            t += x.charAt(i);
+            i++;
+            continue;
+          }
           if (char === '{') {
             count++;
           }
@@ -34,7 +46,6 @@ export default function tokenize(x: string): string[] {
           t += char;
           i++;
         }
-        i++;
       } else {
         while (i < x.length && !isWhiteSpace(x.charAt(i))) {
           t += x.charAt(i);


### PR DESCRIPTION
Two fixes that bring r60.mmel parsing from ~20% to 100%.

## Fix 1: String-aware brace counting in block handler

**Root cause**: The tokenizer's `{...}` block handler counted ALL braces, including those inside quoted strings. OCL expressions like `"ocl{test_loads->forAll(...)}"` have unbalanced braces inside strings, permanently throwing off the count and consuming the rest of the file as one giant block.

**Fix**: Block handler now detects `"` inside blocks and skips to closing `"` without counting intermediate braces.

## Fix 2: Event keyword aliases

Added `start_event`, `end_event`, `signal_catch_event`, `timer_event` as parser keywords (previously only `start`/`end` were registered, but the MMEL spec and all examples use the `_event` suffix).

## Impact

```
Before: 708 tokens, 2 forms, 19 symbols, 9 calculations, 0 events
After:  884 tokens, 37 forms, 30 symbols, 17 calculations, 3 events
```

r60.mmel is now **fully parsed** by the Primmel parser.