### PR TITLE
Add include directive preprocessor for multi-file models

### DIFF
--- a/packages/mmel/src/ser-des/includes.ts
+++ b/packages/mmel/src/ser-des/includes.ts
@@ -1,0 +1,59 @@
+// ─────────────────────────────────────────────────────────────────────
+// Include preprocessor.
+//
+// Resolves `include "path"` directives BEFORE tokenization. The parser
+// sees a single concatenated string with all includes expanded.
+//
+// Design: recursive, relative-path, cycle-detecting. Follows the
+// same convention as C preprocessor #include and AsciiDoc include::.
+// ─────────────────────────────────────────────────────────────────────
+
+import { readFileSync, existsSync } from 'node:fs'
+import { resolve, dirname, isAbsolute } from 'node:path'
+
+const INCLUDE_RE = /^include\s+"([^"]+)"/gm
+
+/**
+ * Preprocess include directives in a .mmel file.
+ *
+ * Reads the file at `filePath`, finds all `include "..."` directives,
+ * recursively resolves them, and returns the concatenated content.
+ *
+ * Include paths are resolved relative to the directory of the
+ * including file. Absolute paths are also supported.
+ *
+ * Cycles are detected and rejected.
+ */
+export function preprocessIncludes(
+  filePath: string,
+  _seen: Set<string> = new Set(),
+): string {
+  const absPath = resolve(filePath)
+
+  if (_seen.has(absPath)) {
+    throw new Error(
+      `Include cycle detected: ${absPath} (chain: ${[..._seen, absPath].map(s => s.split('/').pop()).join(' → ')})`
+    )
+  }
+  _seen.add(absPath)
+
+  if (!existsSync(absPath)) {
+    throw new Error(`Include file not found: ${absPath}`)
+  }
+
+  const content = readFileSync(absPath, 'utf8')
+  const dir = dirname(absPath)
+
+  // Replace each include directive with the preprocessed content of
+  // the referenced file
+  return content.replace(INCLUDE_RE, (match, includePath: string) => {
+    const resolved = isAbsolute(includePath)
+      ? includePath
+      : resolve(dir, includePath)
+
+    // Add .mmel extension if not present
+    const withExt = resolved.endsWith('.mmel') ? resolved : `${resolved}.mmel`
+
+    return preprocessIncludes(withExt, new Set(_seen))
+  })
+}

--- a/packages/mmel/src/ser-des/index.ts
+++ b/packages/mmel/src/ser-des/index.ts
@@ -4,9 +4,23 @@ import resolve from './resolve';
 import _dump from './dump';
 import { PARSER_CONFIG, RESOLVER_CONFIG, DUMPER_CONFIG } from './config';
 
+/**
+ * Parse a .mmel string into a typed Standard.
+ * Does NOT resolve include directives — use loadFile() for that.
+ */
 export function load(mmelString: string): Standard {
   const context = parse(mmelString, PARSER_CONFIG);
   return resolve(context, RESOLVER_CONFIG);
+}
+
+/**
+ * Load a .mmel FILE, resolving include directives first.
+ * Use this when the model uses `include "..."` to split across files.
+ */
+export function loadFile(filePath: string): Standard {
+  const { preprocessIncludes } = require('./includes');
+  const content = preprocessIncludes(filePath);
+  return load(content);
 }
 
 export function dump(standard: Standard): string {


### PR DESCRIPTION
New Primmel feature: `include "path"` resolved BEFORE tokenization.