### PR TITLE
Release @primmel/primmel 1.0.1

### DIFF
--- a/packages/primmel/package.json
+++ b/packages/primmel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primmel/primmel",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Primmel — parser, types, and serializer for the Primmel modelling language (successor to MMEL)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Patch release. Publishes the parser-correctness fixes from #14 to npm so downstream consumers (oimlsmart/smart) can use the published package instead of a local checkout.

## What changed since 1.0.0

- `variable` keyword wired into `PARSER_CONFIG` (was dumper-only, silently dropped on parse)
- Tokenizer: backslash escape sequences in strings (`"he said \"hi\""`)
- Tokenizer: string-awareness in `tokenizeAttributes` (was brace-blind)
- `flow.ts`: forward-compatible skip for unknown edge keywords (label, color) — R 60 model previously crashed the parser
- Dumper: renamed `measurement` keyword → `variable` (per Primmel spec)
- 4 new tests covering the above

## Test plan

- [x] `yarn test` — 67/67 pass
- [x] R 60 model parses cleanly (was throwing before #14)
- [x] `npm pack --dry-run` produces correct tarball

## Publish instructions

After merge:

```sh
cd packages/primmel
npm login    # primmel project account
npm publish  # prepublishOnly runs yarn build → tsc → pack
```

Then tag the release:

```sh
git tag v1.0.1 -m "@primmel/primmel 1.0.1"
git push origin v1.0.1
```
