### PR TITLE
feat: trusted publishing via GitHub Actions OIDC + bump to 1.1.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,56 @@
+name: Publish
+
+# Trusted publishing to npm via GitHub Actions OIDC.
+# Requires the publishing workflow to be configured as a trusted
+# publisher on npm (no NPM_TOKEN needed). See:
+# https://docs.npmjs.com/generating-provenance-statements
+#
+# Triggers when a GitHub Release matching `v*` is published. To publish
+# a new version: bump `packages/primmel/package.json`, merge to main,
+# then create a Release tagged `v<x.y.z>` in the GitHub UI.
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          cache: yarn
+      - name: Enable Corepack
+        run: corepack enable
+      - name: Install
+        run: yarn install --immutable
+      - name: Type-check
+        run: yarn compile
+      - name: Lint
+        run: yarn lint
+      - name: Test
+        run: yarn test
+      - name: Build package
+        run: yarn build
+      - name: Verify version matches the released tag
+        run: |
+          PKG_VERSION=$(node -p "require('./packages/primmel/package.json').version")
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          echo "package.json: $PKG_VERSION"
+          echo "release tag:  $TAG_VERSION"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "Mismatch: package.json $PKG_VERSION != release tag $TAG_VERSION"
+            exit 1
+          fi
+      - name: Publish
+        run: npm publish --provenance --access public
+        working-directory: packages/primmel

--- a/packages/primmel/package.json
+++ b/packages/primmel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primmel/primmel",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Primmel — parser, types, and serializer for the Primmel modelling language (successor to MMEL)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/primmel/test/tokenizer.test.ts
+++ b/packages/primmel/test/tokenizer.test.ts
@@ -64,7 +64,10 @@ describe('tokenize', () => {
   });
 
   it('honours backslash escapes in strings', () => {
-    assert.deepEqual(tokenize('"he said \\"hi\\"" c'), ['"he said \\"hi\\""', 'c']);
+    assert.deepEqual(tokenize('"he said \\"hi\\"" c'), [
+      '"he said \\"hi\\""',
+      'c',
+    ]);
   });
 
   it('does NOT terminate strings on escaped quotes inside brace blocks', () => {


### PR DESCRIPTION
## Summary

Adds `.github/workflows/publish.yml` for npm Trusted Publishing via GitHub Actions OIDC (no `NPM_TOKEN` secret needed). Triggers on release published; runs with `id-token: write` and publishes with `--provenance`.

The publish step verifies `packages/primmel/package.json`'s version matches the release tag before publishing — catches mismatches between git and npm.

Bumps package version `1.0.1` → `1.1.0` (minor) to exercise the trusted-publishing flow end-to-end.

## Test plan

- [x] `yarn compile`, `yarn lint`, `yarn test` (67/67) all green locally
- [ ] After merge: create GitHub Release tagged `v1.1.0`
- [ ] Publish workflow runs and publishes `@primmel/primmel@1.1.0` with provenance
- [ ] Verify at https://www.npmjs.com/package/@primmel/primmel (version 1.1.0, "Provenance" badge visible)
