### PR TITLE
Add term keyword for terminology modeling (MN 113-6)

### DIFF
--- a/packages/primmel/index.ts
+++ b/packages/primmel/index.ts
@@ -40,3 +40,4 @@ export type {
   Transition,
   Cascade,
 } from './src/types/StateMachine';
+export type { default as Term } from './src/types/Term';

--- a/packages/primmel/src/ser-des/config/index.ts
+++ b/packages/primmel/src/ser-des/config/index.ts
@@ -40,7 +40,7 @@ import { dumpLink, parseLink } from './link';
 import { dumpMapProfile, parseMapProfile } from './mapProfile';
 import { dumpViewProfile, parseViewProfile } from './viewProfile';
 
-// Primmel extension parsers/dumpers (MN 113-7 to 113-10)
+// Primmel extension parsers/dumpers (MN 113-6 to 113-10)
 import { dumpForm, parseForm } from './form';
 import { dumpSubformType as dumpSubform, parseSubform } from './subform';
 import { dumpSymbol, parseSymbol, resolveSymbol } from './symbol';
@@ -50,6 +50,7 @@ import {
   resolveCalculation,
 } from './calculation';
 import { dumpStateMachine, parseStateMachine } from './stateMachine';
+import { dumpTerm, parseTerm } from './term';
 
 export const PARSER_CONFIG: ParserConfiguration = {
   root: {
@@ -154,7 +155,11 @@ export const PARSER_CONFIG: ParserConfiguration = {
     parse: parseViewProfile,
   },
 
-  // ── Primmel extension additions (MN 113-7 to 113-10) ─────────────
+  // ── Primmel extension additions (MN 113-6 to 113-10) ─────────────
+  term: {
+    takesID: true,
+    parse: parseTerm,
+  },
   form: {
     takesID: true,
     parse: parseForm,
@@ -309,6 +314,7 @@ export const DUMPER_CONFIG: DumperConfiguration = {
   viewProfiles: dumpViewProfile,
 
   // Primmel extension dumpers
+  terms: dumpTerm,
   forms: dumpForm,
   subforms: dumpSubform,
   symbols: dumpSymbol,

--- a/packages/primmel/src/ser-des/config/term.ts
+++ b/packages/primmel/src/ser-des/config/term.ts
@@ -1,0 +1,72 @@
+import type { Dumper, Parser } from '../types';
+import { removePackage, tokenizePackage } from '../tokenize';
+import type Term from '../../types/Term';
+
+export const parseTerm: Parser = function (id, data) {
+  const result: Term = {
+    id,
+    label: '',
+    definition: '',
+    symbolId: '',
+    referenceIds: [],
+    ref: [],
+  };
+
+  if (data !== '') {
+    const t: Array<string> = tokenizePackage(data);
+    let i = 0;
+    while (i < t.length) {
+      const command: string = t[i++];
+      if (i < t.length) {
+        if (command === 'label') {
+          result.label = removePackage(t[i++]);
+        } else if (command === 'definition') {
+          result.definition = removePackage(t[i++]);
+        } else if (command === 'symbol') {
+          // symbol reference is a bare ID (e.g., `symbol Emax`).
+          // Strip wrapping quotes if present (defensive — most models use bare IDs).
+          const raw = t[i++];
+          result.symbolId =
+            raw.length >= 2 && raw.charAt(0) === '"' && raw.charAt(raw.length - 1) === '"'
+              ? raw.slice(1, -1)
+              : raw;
+        } else if (command === 'reference') {
+          result.referenceIds = tokenizePackage(t[i++]);
+        } else {
+          i++; // forward-compatible: skip unknown keyword value
+        }
+      } else {
+        throw new Error(
+          `Parsing error: term. ID ${id}: Expecting value for ${command}`,
+        );
+      }
+    }
+  }
+
+  return ctx => {
+    ctx.terms[id] = result;
+    return ctx;
+  };
+};
+
+export const dumpTerm: Dumper<Term> = function (term) {
+  let out: string = 'term ' + term.id + ' {\n';
+  if (term.label) {
+    out += '  label "' + term.label + '"\n';
+  }
+  if (term.definition) {
+    out += '  definition "' + term.definition + '"\n';
+  }
+  if (term.symbolId) {
+    out += '  symbol ' + term.symbolId + '\n';
+  }
+  if (term.referenceIds.length > 0) {
+    out += '  reference {\n';
+    for (const r of term.referenceIds) {
+      out += '    ' + r + '\n';
+    }
+    out += '  }\n';
+  }
+  out += '}\n';
+  return out;
+};

--- a/packages/primmel/src/ser-des/parse.ts
+++ b/packages/primmel/src/ser-des/parse.ts
@@ -37,7 +37,8 @@ export default function parse(
     links: {},
     mapProfiles: {},
     viewProfiles: {},
-    // Primmel extensions (MN 113-7 to 113-10)
+    // Primmel extensions (MN 113-6 to 113-10)
+    terms: {},
     forms: {},
     subforms: {},
     symbols: {},

--- a/packages/primmel/src/ser-des/resolve.ts
+++ b/packages/primmel/src/ser-des/resolve.ts
@@ -76,6 +76,7 @@ export default function resolve(
     links: Object.values(ctx.links),
     mapProfiles: Object.values(ctx.mapProfiles),
     viewProfiles: Object.values(ctx.viewProfiles),
+    terms: Object.values(ctx.terms),
     forms: Object.values(ctx.forms),
     subforms: Object.values(ctx.subforms),
     symbols: [],

--- a/packages/primmel/src/ser-des/types.ts
+++ b/packages/primmel/src/ser-des/types.ts
@@ -19,6 +19,7 @@ import type StateMachine from '../types/StateMachine';
 import type Subform from '../types/Subform';
 import type Symbol from '../types/Symbol';
 import type Table from '../types/Table';
+import type Term from '../types/Term';
 import type ViewProfile from '../types/ViewProfile';
 
 // Configuration
@@ -97,7 +98,8 @@ export interface ParseContext {
   mapProfiles: Record<string, MapProfile>;
   viewProfiles: Record<string, ViewProfile>;
 
-  // Primmel extensions (MN 113-7 to 113-10)
+  // Primmel extensions (MN 113-6 to 113-10)
+  terms: Record<string, Term>;
   forms: Record<string, Form>;
   subforms: Record<string, Subform>;
   symbols: Record<string, Symbol>;

--- a/packages/primmel/src/types/Standard.ts
+++ b/packages/primmel/src/types/Standard.ts
@@ -18,6 +18,7 @@ import type StateMachine from './StateMachine';
 import type Subform from './Subform';
 import type Symbol from './Symbol';
 import type Table from './Table';
+import type Term from './Term';
 import type ViewProfile from './ViewProfile';
 
 export default interface Standard {
@@ -44,7 +45,8 @@ export default interface Standard {
   mapProfiles: MapProfile[];
   viewProfiles: ViewProfile[];
 
-  // Primmel extensions (MN 113-7 to 113-10)
+  // Primmel extensions (MN 113-6 to 113-10)
+  terms: Term[];
   forms: Form[];
   subforms: Subform[];
   symbols: Symbol[];

--- a/packages/primmel/src/types/Term.ts
+++ b/packages/primmel/src/types/Term.ts
@@ -1,0 +1,24 @@
+import type Reference from './Reference';
+
+/**
+ * A formal term definition from a standard's terminology section.
+ *
+ * Terms are first-class modelling constructs: they capture the natural-language
+ * definition of a concept, optionally cross-referenced to a declared `symbol`
+ * (for terms that have a quantitative representation) and to the source clause
+ * (e.g., R 60-1 §3.5.5 defines Emax).
+ *
+ * See Primmel spec MN 113-6 §2 (Term syntax).
+ */
+interface Term {
+  id: string;
+  label: string;
+  definition: string;
+  // Optional cross-reference: when a term has a quantitative form, this is
+  // the id of the corresponding `symbol` declaration.
+  symbolId: string;
+  referenceIds: string[];
+  ref: Reference[];
+}
+
+export default Term;

--- a/packages/primmel/test/term.test.ts
+++ b/packages/primmel/test/term.test.ts
@@ -1,0 +1,77 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { load, dump } from '../index.ts';
+
+describe('term keyword', () => {
+  it('parses a minimal term', () => {
+    const src = `
+      term maximum-capacity {
+        label "Maximum capacity"
+        definition "The maximum load that a load cell is designed to measure"
+      }
+    `;
+    const s = load(src);
+    assert.equal(s.terms.length, 1);
+    assert.equal(s.terms[0].id, 'maximum-capacity');
+    assert.equal(s.terms[0].label, 'Maximum capacity');
+    assert.equal(s.terms[0].definition, 'The maximum load that a load cell is designed to measure');
+    assert.equal(s.terms[0].symbolId, '');
+    assert.deepEqual(s.terms[0].referenceIds, []);
+  });
+
+  it('parses a term with symbol cross-reference and references', () => {
+    const src = `
+      term maximum-capacity {
+        label "Maximum capacity"
+        definition "..."
+        symbol Emax
+        reference { R60-1-3-3 }
+      }
+    `;
+    const s = load(src);
+    assert.equal(s.terms[0].symbolId, 'Emax');
+    assert.deepEqual(s.terms[0].referenceIds, ['R60-1-3-3']);
+  });
+
+  it('dumps a term round-trip', () => {
+    const src = `
+      term dr {
+        label "Minimum dead load output return"
+        definition "DR concept"
+        symbol DR
+        reference { R60-1-3-5-10 }
+      }
+    `;
+    const s = load(src);
+    const out = dump(s);
+    assert.match(out, /term dr \{/);
+    assert.match(out, /label "Minimum dead load output return"/);
+    assert.match(out, /symbol DR/);
+    assert.match(out, /R60-1-3-5-10/);
+  });
+
+  it('forward-compat: unknown sub-keywords inside a term are skipped', () => {
+    const src = `
+      term x {
+        label "X"
+        future_field value
+      }
+    `;
+    const s = load(src);
+    assert.equal(s.terms.length, 1);
+    assert.equal(s.terms[0].label, 'X');
+  });
+
+  it('tolerates quoted symbol id (defensive)', () => {
+    // The dumper writes bare IDs (`symbol Emax`). Quoted form is accepted
+    // defensively but not the canonical form.
+    const src = `
+      term x {
+        label "X"
+        symbol "Emax"
+      }
+    `;
+    const s = load(src);
+    assert.equal(s.terms[0].symbolId, 'Emax');
+  });
+});


### PR DESCRIPTION
## Summary

Add a new `term` keyword to the Primmel DSL for terminology modeling — the 6th Primmel extension. Fills a real gap: the R 60 model had an empty `r60-terminology.mmel` placeholder; now it has 36 terms cross-referenced to symbols and source clauses.

## Syntax

    term maximum-capacity {
      label "Maximum capacity"
      definition "largest value of a quantity expressed in units of mass, which may be applied to a load cell"
      symbol Emax
      reference { R60-1-3-5-5 }
    }

Each term captures:
- **id**: kebab-case slug
- **label**: human-readable name
- **definition**: formal text
- **symbolId**: optional cross-reference to a declared `symbol` (for terms with quantitative form)
- **referenceIds**: source clause references

## Why this matters

The audit caught that `r60-terminology.mmel` was an empty placeholder despite the user's "fully model R 60" directive. R 60-1 §3 defines ~30 terms that are foundational to the entire model — DR, Emax, Emin, vmin, Y, Z, nLC, pLC, etc. These terms are the semantic anchor for every other construct.

Without `term`, the model had no way to capture the natural-language definitions of these concepts. Symbols covered the quantitative form, but the human-readable definitions (and their cross-references to source clauses) were nowhere.

## OCP compliance

Adding `term` required:
- ✅ One new file: `src/ser-des/config/term.ts`
- ✅ One new file: `src/types/Term.ts`
- ✅ Wiring in central registries (`PARSER_CONFIG`, `DUMPER_CONFIG`)
- ✅ Type additions to `Standard` and `ParseContext`

No existing parser/dumper was modified. The keyword is additive — older models without `term` continue to parse identically.

## Test plan

- [x] `yarn test` — all 72 tests pass (added 5 new term tests)
- [x] R 60 model parses with 36 terms loaded (15 with symbol cross-refs)
- [x] Round-trip works (`parse → dump → parse` produces equivalent AST)

## Files

- `src/types/Term.ts` — interface
- `src/ser-des/config/term.ts` — parser + dumper
- `test/term.test.ts` — 5 tests
- `src/types/Standard.ts` — add `terms: Term[]`
- `src/ser-des/types.ts` — add `terms` to ParseContext
- `src/ser-des/parse.ts` — initialize `terms: {}`
- `src/ser-des/resolve.ts` — include in output
- `src/ser-des/config/index.ts` — register keyword
- `index.ts` — export Term type

## Companion PR

[primmel/spec#12](https://github.com/primmel/spec/pull/12) — populates `r60-terminology.mmel` with 36 terms from R 60-1 §3.
