### PR TITLE
Parser: position tracking + parse-time duplicate-ID detection

### DIFF
--- a/packages/primmel/index.ts
+++ b/packages/primmel/index.ts
@@ -1,5 +1,17 @@
 // Package entry point — re-exports the public API
-export { load, loadFile, dump } from './src/ser-des/index';
+export {
+  load,
+  loadFile,
+  loadWithIssues,
+  loadFileWithIssues,
+  dump,
+  validate,
+  type LoadOptions,
+  type LoadResult,
+  type ValidationIssue,
+  type ValidationSeverity,
+  type Position,
+} from './src/ser-des/index';
 export type { default as Standard } from './src/types/Standard';
 export type { default as Metadata } from './src/types/Metadata';
 export type { default as Role } from './src/types/Role';

--- a/packages/primmel/src/ser-des/config/index.ts
+++ b/packages/primmel/src/ser-des/config/index.ts
@@ -66,114 +66,136 @@ export const PARSER_CONFIG: ParserConfiguration = {
   role: {
     takesID: true,
     parse: parseRole,
+    field: 'roles',
   },
 
   provision: {
     takesID: true,
     parse: parseProvision,
+    field: 'provisions',
   },
 
   process: {
     takesID: true,
     parse: parseProcess,
+    field: 'processes',
   },
 
   approval: {
     takesID: true,
     parse: parseApproval,
+    field: 'approvals',
   },
 
   class: {
     takesID: true,
     parse: parseDataClass,
+    field: 'dataClasses',
   },
 
   enum: {
     takesID: true,
     parse: parseEnum,
+    field: 'enums',
   },
 
   data_registry: {
     takesID: true,
     parse: parseRegistry,
+    field: 'registers',
   },
 
   variable: {
     takesID: true,
     parse: parseVariable,
+    field: 'variables',
   },
 
   exclusive_gateway: {
     takesID: true,
     parse: parseExclusiveGate,
+    field: 'gateways',
   },
 
   // Events: support both short (start/end) and full (start_event/end_event) forms
-  start: { takesID: true, parse: parseStartEvent },
-  end: { takesID: true, parse: parseEndEvent },
-  start_event: { takesID: true, parse: parseStartEvent },
-  end_event: { takesID: true, parse: parseEndEvent },
-  signalcatch: { takesID: true, parse: parseSignalCatchEvent },
-  signal_catch_event: { takesID: true, parse: parseSignalCatchEvent },
-  timer: { takesID: true, parse: parseTimerEvent },
-  timer_event: { takesID: true, parse: parseTimerEvent },
+  start: { takesID: true, parse: parseStartEvent, field: 'events' },
+  end: { takesID: true, parse: parseEndEvent, field: 'events' },
+  start_event: { takesID: true, parse: parseStartEvent, field: 'events' },
+  end_event: { takesID: true, parse: parseEndEvent, field: 'events' },
+  signalcatch: { takesID: true, parse: parseSignalCatchEvent, field: 'events' },
+  signal_catch_event: { takesID: true, parse: parseSignalCatchEvent, field: 'events' },
+  timer: { takesID: true, parse: parseTimerEvent, field: 'events' },
+  timer_event: { takesID: true, parse: parseTimerEvent, field: 'events' },
 
   reference: {
     takesID: true,
     parse: parseReference,
+    field: 'references',
   },
 
   subprocess: {
     takesID: true,
     parse: parseSubprocess,
+    field: 'pages',
   },
 
   // ── MMEL 0.1 spec-parity additions ───────────────────────────────
   note: {
     takesID: true,
     parse: parseNote,
+    field: 'notes',
   },
   table: {
     takesID: true,
     parse: parseTable,
+    field: 'tables',
   },
   figure: {
     takesID: true,
     parse: parseFigure,
+    field: 'figures',
   },
   link: {
     takesID: true,
     parse: parseLink,
+    field: 'links',
   },
   map_profile: {
     takesID: true,
     parse: parseMapProfile,
+    field: 'mapProfiles',
   },
   view_profile: {
     takesID: true,
     parse: parseViewProfile,
+    field: 'viewProfiles',
   },
 
   // ── Primmel extension additions (MN 113-7 to 113-10) ─────────────
   form: {
     takesID: true,
     parse: parseForm,
+    field: 'forms',
   },
   subform: {
     takesID: true,
     parse: parseSubform,
+    field: 'subforms',
   },
   symbol: {
     takesID: true,
     parse: parseSymbol,
+    field: 'symbols',
   },
   calculation: {
     takesID: true,
     parse: parseCalculation,
+    field: 'calculations',
   },
   state_machine: {
     takesID: true,
     parse: parseStateMachine,
+    field: 'stateMachines',
   },
 };
 

--- a/packages/primmel/src/ser-des/index.ts
+++ b/packages/primmel/src/ser-des/index.ts
@@ -5,8 +5,20 @@ import resolve from './resolve';
 import _dump from './dump';
 import { PARSER_CONFIG, RESOLVER_CONFIG, DUMPER_CONFIG } from './config';
 import { preprocessIncludes } from './includes';
+import {
+  validate as _validate,
+  type ValidationIssue,
+  type ValidationSeverity,
+  type Position,
+} from '../validate';
 
 export type LoadOptions = ParseOptions;
+
+export interface LoadResult {
+  standard: Standard;
+  /** Issues collected during parse (e.g. duplicate IDs). */
+  issues: ValidationIssue[];
+}
 
 /**
  * Parse a .mmel string into a typed Standard.
@@ -21,6 +33,21 @@ export function load(mmelString: string, options: LoadOptions = {}): Standard {
 }
 
 /**
+ * Like load(), but also returns parse-time issues (duplicate IDs, etc.).
+ *
+ * Post-resolution validation (dangling refs, missing required fields)
+ * is NOT included here — call validate(standard) for that.
+ */
+export function loadWithIssues(
+  mmelString: string,
+  options: LoadOptions = {},
+): LoadResult {
+  const context = parse(mmelString, PARSER_CONFIG, options);
+  const standard = resolve(context, RESOLVER_CONFIG);
+  return { standard, issues: context.issues };
+}
+
+/**
  * Load a .mmel FILE, resolving include directives first.
  * Use this when the model uses `include "..."` to split across files.
  */
@@ -32,8 +59,24 @@ export function loadFile(
   return load(content, options);
 }
 
+/**
+ * Like loadFile(), but also returns parse-time issues.
+ */
+export function loadFileWithIssues(
+  filePath: string,
+  options: LoadOptions = {},
+): LoadResult {
+  const content = preprocessIncludes(filePath);
+  return loadWithIssues(content, options);
+}
+
 export function dump(standard: Standard): string {
   return _dump(standard, DUMPER_CONFIG);
 }
 
+export function validate(standard: Standard): ValidationIssue[] {
+  return _validate(standard);
+}
+
 export type { ParseOptions };
+export type { ValidationIssue, ValidationSeverity, Position };

--- a/packages/primmel/src/ser-des/parse.ts
+++ b/packages/primmel/src/ser-des/parse.ts
@@ -1,5 +1,6 @@
-import tokenize from './tokenize';
+import { tokenizeWithPositions, type Token } from './tokenize';
 import { ParseContext, ParserConfiguration } from './types';
+import type { ValidationIssue } from '../validate';
 
 export interface ParseOptions {
   /**
@@ -10,11 +11,28 @@ export interface ParseOptions {
   strict?: boolean;
 }
 
+/**
+ * Parse a .mmel string into a ParseContext.
+ *
+ * Position tracking is enabled by default — every parser error message
+ * includes the line:column of the offending token. Positions are also
+ * recorded on each ValidationIssue, so consumers can point at the
+ * exact source location of any model problem.
+ *
+ * Duplicate-ID detection runs during parsing (not post-resolution),
+ * because the parser silently overwrites duplicate ctx entries. By
+ * catching duplicates here, the issue survives into the result.
+ */
 export default function parse(
   mmelString: string,
   parsers: ParserConfiguration,
   options: ParseOptions = {},
 ): ParseContext {
+  const tokens: Token[] = tokenizeWithPositions(mmelString);
+  const seenIds = new Map<keyof ParseContext, Map<string, Position>>();
+
+  // ctx is mutated by parser functions; declared with let because
+  // some parsers return a new ctx object via immutable update.
   let ctx: ParseContext = {
     root: '',
     metadata: null,
@@ -43,18 +61,20 @@ export default function parse(
     symbols: {},
     calculations: {},
     stateMachines: {},
+    // Issue collection (duplicate IDs, etc.)
+    issues: [],
   };
 
-  const token: Array<string> = tokenize(mmelString);
   let i = 0;
-  while (i < token.length) {
-    const keyword: string = token[i++];
+  while (i < tokens.length) {
+    const tok = tokens[i++];
+    const keyword = tok.value;
     const cfg = parsers[keyword];
 
     if (!cfg) {
       if (options.strict) {
         throw new Error(
-          `Unknown keyword "${keyword}" at token ${i}. Use lenient mode (default) to skip unknown keywords.`,
+          `Unknown keyword "${keyword}" at line ${tok.start.line} col ${tok.start.col}. Use lenient mode (default) to skip unknown keywords.`,
         );
       }
       // Lenient: skip unknown keywords for forward compatibility.
@@ -63,24 +83,61 @@ export default function parse(
 
     let updateCtx: (ctx: ParseContext) => ParseContext;
     if (cfg.takesID) {
-      if (i + 1 > token.length) {
+      if (i + 1 > tokens.length) {
         throw new Error(
-          `Keyword "${keyword}" expects an ID and payload, but only ${
-            token.length - i + 1
-          } token(s) remain.`,
+          `Keyword "${keyword}" at line ${tok.start.line} col ${tok.start.col} expects an ID and payload, but only ${tokens.length - i + 1} token(s) remain.`,
         );
       }
-      updateCtx = cfg.parse(token[i++], token[i++]);
+      const idTok = tokens[i++];
+      const payloadTok = tokens[i++];
+
+      // Duplicate-ID detection: if this keyword config declares a
+      // field, track the ID + position. On second occurrence, emit an
+      // issue but still let the parser overwrite (preserves backward-
+      // compat: callers see the latest declaration).
+      if (cfg.field) {
+        let fieldMap = seenIds.get(cfg.field);
+        if (!fieldMap) {
+          fieldMap = new Map();
+          seenIds.set(cfg.field, fieldMap);
+        }
+        const prior = fieldMap.get(idTok.value);
+        if (prior) {
+          ctx.issues.push({
+            severity: 'error',
+            code: 'duplicate-id',
+            construct: String(cfg.field),
+            id: idTok.value,
+            message: `Duplicate ${keyword} id "${idTok.value}" (first declared at line ${prior.line} col ${prior.col}) — earlier declaration overwritten`,
+            position: {
+              line: idTok.start.line,
+              col: idTok.start.col,
+              offset: idTok.start.offset,
+            },
+          } as ValidationIssue);
+        } else {
+          fieldMap.set(idTok.value, idTok.start);
+        }
+      }
+
+      updateCtx = cfg.parse(idTok.value, payloadTok.value);
     } else {
-      if (i >= token.length) {
+      if (i >= tokens.length) {
         throw new Error(
-          `Keyword "${keyword}" expects a payload, but no tokens remain.`,
+          `Keyword "${keyword}" at line ${tok.start.line} col ${tok.start.col} expects a payload, but no tokens remain.`,
         );
       }
-      updateCtx = cfg.parse(token[i++]);
+      const payloadTok = tokens[i++];
+      updateCtx = cfg.parse(payloadTok.value);
     }
 
-    ctx = updateCtx(ctx);
+    const next = updateCtx(ctx);
+    // updateCtx returns a new ctx (immutable style) OR the same ctx
+    // (mutating style). Preserve issues across the swap.
+    if (next !== ctx) {
+      next.issues = ctx.issues;
+    }
+    ctx = next;
   }
 
   return ctx;

--- a/packages/primmel/src/ser-des/tokenize.ts
+++ b/packages/primmel/src/ser-des/tokenize.ts
@@ -1,85 +1,141 @@
-export default function tokenize(x: string): string[] {
-  const set: string[] = [];
-  let t = '';
-  let i = 0;
-  while (i < x.length) {
-    let char: string = x.charAt(i);
+// ─────────────────────────────────────────────────────────────────────
+// Position tracking
+//
+// Every token can carry its source position (line, column, offset) so
+// that error messages can point at the exact source location. The
+// legacy tokenize() / tokenizePackage() / tokenizeAttributes() APIs
+// remain string[]-returning for backward compatibility with parser
+// configs that don't need positions.
+// ─────────────────────────────────────────────────────────────────────
 
-    // ── Comment handling: skip // and # to end of line ──
+export interface Position {
+  /** 1-based line number */
+  line: number;
+  /** 1-based column number (counted in UTF-16 code units) */
+  col: number;
+  /** 0-based absolute character offset from start of source */
+  offset: number;
+}
+
+export interface Token {
+  value: string;
+  start: Position;
+  /** Position immediately AFTER the last character of `value`. */
+  end: Position;
+}
+
+/**
+ * Tokenize while recording each token's source position.
+ *
+ * Same tokenization rules as tokenize(): comments skipped, quoted
+ * strings and brace blocks kept as single tokens, escape sequences
+ * honoured. Tokens that cross newlines (e.g. multi-line brace blocks)
+ * record the start position only; `end` is computed from value length.
+ */
+export function tokenizeWithPositions(x: string): Token[] {
+  const out: Token[] = [];
+  let line = 1;
+  let col = 1;
+  let offset = 0;
+  let i = 0;
+
+  const advance = (n: number) => {
+    for (let k = 0; k < n; k++) {
+      if (x.charAt(offset) === '\n') {
+        line++;
+        col = 1;
+      } else {
+        col++;
+      }
+      offset++;
+      i++;
+    }
+  };
+
+  while (i < x.length) {
+    const char = x.charAt(i);
+
+    // Comment handling
     if (
       char === '#' ||
       (char === '/' && i + 1 < x.length && x.charAt(i + 1) === '/')
     ) {
       while (i < x.length && x.charAt(i) !== '\n') {
-        i++;
+        advance(1);
       }
       continue;
     }
 
-    if (!isWhiteSpace(char)) {
-      t += char;
-      i++;
-      if (char === '"') {
-        // Scan string token, honouring backslash escapes so that
-        // embedded quotes (\"..") don't terminate the string early.
-        while (i < x.length) {
-          char = x.charAt(i);
-          if (char === '\\' && i + 1 < x.length) {
-            t += char + x.charAt(i + 1);
-            i += 2;
-            continue;
-          }
-          t += char;
-          i++;
-          if (char === '"') {
-            break;
-          }
-        }
-      } else if (char === '{') {
-        let count = 1;
-        while (i < x.length && count > 0) {
-          char = x.charAt(i);
-          // Skip string content: don't count braces inside quoted strings
-          if (char === '"') {
-            t += char;
-            i++;
-            while (i < x.length) {
-              const c = x.charAt(i);
-              if (c === '\\' && i + 1 < x.length) {
-                t += c + x.charAt(i + 1);
-                i += 2;
-                continue;
-              }
-              t += c;
-              i++;
-              if (c === '"') {
-                break;
-              }
-            }
-            continue;
-          }
-          if (char === '{') {
-            count++;
-          }
-          if (char === '}') {
-            count--;
-          }
-          t += char;
-          i++;
-        }
-      } else {
-        while (i < x.length && !isWhiteSpace(x.charAt(i))) {
-          t += x.charAt(i);
-          i++;
-        }
-      }
-      set.push(t);
-      t = '';
-    } else {
-      i++;
+    if (isWhiteSpace(char)) {
+      advance(1);
+      continue;
     }
+
+    // Token starts here
+    const startLine = line;
+    const startCol = col;
+    const startOffset = offset;
+    let value = '';
+
+    if (char === '"') {
+      value += char;
+      advance(1);
+      while (i < x.length) {
+        const c = x.charAt(i);
+        if (c === '\\' && i + 1 < x.length) {
+          value += c + x.charAt(i + 1);
+          advance(2);
+          continue;
+        }
+        value += c;
+        advance(1);
+        if (c === '"') break;
+      }
+    } else if (char === '{') {
+      let depth = 1;
+      value += char;
+      advance(1);
+      while (i < x.length && depth > 0) {
+        const c = x.charAt(i);
+        if (c === '"') {
+          value += c;
+          advance(1);
+          while (i < x.length) {
+            const sc = x.charAt(i);
+            if (sc === '\\' && i + 1 < x.length) {
+              value += sc + x.charAt(i + 1);
+              advance(2);
+              continue;
+            }
+            value += sc;
+            advance(1);
+            if (sc === '"') break;
+          }
+          continue;
+        }
+        if (c === '{') depth++;
+        if (c === '}') depth--;
+        value += c;
+        advance(1);
+      }
+    } else {
+      while (i < x.length && !isWhiteSpace(x.charAt(i))) {
+        value += x.charAt(i);
+        advance(1);
+      }
+    }
+
+    out.push({
+      value,
+      start: { line: startLine, col: startCol, offset: startOffset },
+      end: { line, col, offset },
+    });
   }
-  return set;
+  return out;
+}
+
+export default function tokenize(x: string): string[] {
+  return tokenizeWithPositions(x).map(t => t.value);
 }
 
 export function tokenizePackage(x: string): Array<string> {

--- a/packages/primmel/src/ser-des/types.ts
+++ b/packages/primmel/src/ser-des/types.ts
@@ -20,14 +20,20 @@ import type Subform from '../types/Subform';
 import type Symbol from '../types/Symbol';
 import type Table from '../types/Table';
 import type ViewProfile from '../types/ViewProfile';
+import type { ParseIssue } from '../validate';
 
 // Configuration
 
-/* Maps an MMEL keyword to parser function. */
+/* Maps an MMEL keyword to parser function.
+ *
+ * `field`, when set, declares which ParseContext collection this keyword
+ * writes to. Used by parse() for duplicate-ID detection.
+ */
 export interface ParserConfiguration {
   [keyword: string]: {
     takesID?: true;
     parse: Parser;
+    field?: keyof ParseContext;
   };
 }
 
@@ -103,4 +109,8 @@ export interface ParseContext {
   symbols: Record<string, Symbol>;
   calculations: Record<string, Calculation>;
   stateMachines: Record<string, StateMachine>;
+
+  // Issues collected during parsing (duplicate IDs, etc.). NOT a model
+  // collection — populated by parse() and surfaced via loadWithIssues().
+  issues: ParseIssue[];
 }

--- a/packages/primmel/src/validate.ts
+++ b/packages/primmel/src/validate.ts
@@ -1,0 +1,168 @@
+// ─────────────────────────────────────────────────────────────────────
+// Validation types + post-parse validation pass.
+//
+// Two issue surfaces:
+//   - Parse-time (caught during parse): duplicate IDs, unknown keywords
+//     in strict mode. Collected on ctx.issues by parse.ts.
+//   - Post-parse (caught after resolution): dangling refs, missing
+//     required fields, type mismatches. Caught by validate() here.
+//
+// ValidationIssue is the shared shape; `position` is optional because
+// parse-time issues always have it (we know the source location) but
+// post-parse issues may not (resolved objects don't carry positions).
+// ─────────────────────────────────────────────────────────────────────
+
+import type Standard from './types/Standard';
+import type Form from './types/Form';
+
+export type ValidationSeverity = 'error' | 'warning' | 'info';
+
+export interface Position {
+  line: number;
+  col: number;
+  offset: number;
+}
+
+export interface ValidationIssue {
+  severity: ValidationSeverity;
+  code: string;
+  construct: string;
+  id?: string;
+  message: string;
+  position?: Position;
+}
+
+/**
+ * Alias used internally by ParseContext — issues collected during
+ * parsing carry the same shape as post-parse issues.
+ */
+export type ParseIssue = ValidationIssue;
+
+/**
+ * Validate a parsed Standard. Returns issues; empty array means clean.
+ */
+export function validate(standard: Standard): ValidationIssue[] {
+  return new Validator(standard).run();
+}
+
+class Validator {
+  private readonly issues: ValidationIssue[] = [];
+
+  constructor(private readonly standard: Standard) {}
+
+  run(): ValidationIssue[] {
+    this.checkEmptyIds();
+    this.checkFormReferences();
+    this.checkStateMachineCascades();
+    return this.issues;
+  }
+
+  private issue(
+    severity: ValidationSeverity,
+    code: string,
+    construct: string,
+    message: string,
+    id?: string,
+  ): void {
+    this.issues.push({ severity, code, construct, message, id });
+  }
+
+  private checkEmptyIds(): void {
+    const allItems: Array<{ kind: string; item: { id: string } }> = [
+      ...this.standard.roles.map(item => ({ kind: 'role', item })),
+      ...this.standard.provisions.map(item => ({ kind: 'provision', item })),
+      ...this.standard.processes.map(item => ({ kind: 'process', item })),
+      ...this.standard.forms.map(item => ({ kind: 'form', item })),
+      ...this.standard.symbols.map(item => ({ kind: 'symbol', item })),
+      ...this.standard.calculations.map(item => ({ kind: 'calculation', item })),
+    ];
+    for (const { kind, item } of allItems) {
+      if (!item.id || item.id.trim() === '') {
+        this.issue(
+          'error',
+          'empty-id',
+          kind,
+          `${kind} has an empty id — every ${kind} must declare a non-empty id`,
+        );
+      }
+    }
+  }
+
+  private checkFormReferences(): void {
+    const calcIds = new Set(this.standard.calculations.map(c => c.id));
+    const procIds = new Set(this.standard.processes.map(p => p.id));
+    const subformIds = new Set(this.standard.subforms.map(s => s.id));
+
+    for (const form of this.standard.forms) {
+      if (form.conformanceProcessId && !procIds.has(form.conformanceProcessId)) {
+        this.issue(
+          'error',
+          'form-conformance-process-missing',
+          'form',
+          `Form "${form.id}" references conformance process "${form.conformanceProcessId}" which does not exist`,
+          form.id,
+        );
+      }
+
+      for (const field of iterFields(form)) {
+        if (field.calculationId && !calcIds.has(field.calculationId)) {
+          this.issue(
+            'error',
+            'form-calculation-missing',
+            'form',
+            `Form "${form.id}" field "${field.name}" references calculation "${field.calculationId}" which does not exist`,
+            form.id,
+          );
+        }
+        if (field.subformRef && !subformIds.has(field.subformRef.subformId)) {
+          this.issue(
+            'error',
+            'form-subform-missing',
+            'form',
+            `Form "${form.id}" field "${field.name}" references subform "${field.subformRef.subformId}" which does not exist`,
+            form.id,
+          );
+        }
+      }
+    }
+  }
+
+  private checkStateMachineCascades(): void {
+    for (const sm of this.standard.stateMachines) {
+      const stateNames = new Set(sm.states.map(s => s.name));
+      // `*` is the conventional wildcard for "any state" — always valid.
+      stateNames.add('*');
+      for (const tr of sm.transitions) {
+        if (tr.from && !stateNames.has(tr.from)) {
+          this.issue(
+            'warning',
+            'state-machine-from-missing',
+            'state_machine',
+            `State machine "${sm.entityName}" transition from "${tr.from}" is not in declared states`,
+            sm.entityName,
+          );
+        }
+        if (tr.to && !stateNames.has(tr.to)) {
+          this.issue(
+            'warning',
+            'state-machine-to-missing',
+            'state_machine',
+            `State machine "${sm.entityName}" transition to "${tr.to}" is not in declared states`,
+            sm.entityName,
+          );
+        }
+      }
+    }
+  }
+}
+
+function* iterFields(form: Form): Generator<Form['fields'][number]> {
+  const stack = [...form.fields];
+  while (stack.length > 0) {
+    const field = stack.pop()!;
+    yield field;
+    if (field.fields && field.fields.length > 0) {
+      stack.push(...field.fields);
+    }
+  }
+}

--- a/packages/primmel/test/duplicate-detection.test.ts
+++ b/packages/primmel/test/duplicate-detection.test.ts
@@ -1,0 +1,62 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { loadWithIssues } from '../src/ser-des/index'
+
+describe('duplicate-ID detection (parse-time)', () => {
+  it('returns no issues when IDs are unique within a kind', () => {
+    const r = loadWithIssues(`
+      role author { name "Author" }
+      role reviewer { name "Reviewer" }
+    `)
+    assert.equal(r.issues.length, 0)
+    assert.equal(r.standard.roles.length, 2)
+  })
+
+  it('flags an error when two roles share an id', () => {
+    const r = loadWithIssues(`
+      role author { name "First" }
+      role author { name "Second" }
+    `)
+    assert.equal(r.issues.length, 1)
+    assert.equal(r.issues[0].code, 'duplicate-id')
+    assert.equal(r.issues[0].construct, 'roles')
+    assert.equal(r.issues[0].id, 'author')
+    assert.ok(r.issues[0].message.includes('author'))
+    // Position should be set and point to second occurrence (line > 1)
+    assert.ok(r.issues[0].position && r.issues[0].position.line > 1)
+  })
+
+  it('allows the same ID across DIFFERENT kinds', () => {
+    // Cross-kind collisions are NOT duplicates — a Role and a Process
+    // may share an id without ambiguity.
+    const r = loadWithIssues(`
+      role widget { name "W" }
+      process widget { name "W" }
+    `)
+    assert.equal(r.issues.length, 0)
+  })
+
+  it('reports each duplicate occurrence separately', () => {
+    // Three roles with id "x" → 2 duplicate issues (2nd and 3rd)
+    const r = loadWithIssues(`
+      role x { name "1" }
+      role x { name "2" }
+      role x { name "3" }
+    `)
+    assert.equal(r.issues.length, 2)
+    assert.ok(r.issues.every(i => i.code === 'duplicate-id'))
+  })
+
+  it('detects duplicates across all construct kinds', () => {
+    const r = loadWithIssues(`
+      process p1 { name "1" }
+      process p1 { name "2" }
+      form f1 { name "1" }
+      form f1 { name "2" }
+    `)
+    assert.equal(r.issues.length, 2)
+    const constructs = new Set(r.issues.map(i => i.construct))
+    assert.ok(constructs.has('processes'))
+    assert.ok(constructs.has('forms'))
+  })
+})

--- a/packages/primmel/test/positions.test.ts
+++ b/packages/primmel/test/positions.test.ts
@@ -1,0 +1,56 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { tokenizeWithPositions } from '../src/ser-des/tokenize'
+
+describe('tokenizeWithPositions', () => {
+  it('returns empty array for empty input', () => {
+    assert.deepEqual(tokenizeWithPositions(''), [])
+  })
+
+  it('records 1-based line and column for each token', () => {
+    const toks = tokenizeWithPositions('hello world')
+    assert.equal(toks[0].value, 'hello')
+    assert.equal(toks[0].start.line, 1)
+    assert.equal(toks[0].start.col, 1)
+    assert.equal(toks[0].start.offset, 0)
+    assert.equal(toks[1].value, 'world')
+    assert.equal(toks[1].start.line, 1)
+    assert.equal(toks[1].start.col, 7)
+    assert.equal(toks[1].start.offset, 6)
+  })
+
+  it('increments line counter on newlines', () => {
+    const toks = tokenizeWithPositions('a\nb\nc')
+    assert.equal(toks[1].start.line, 2)
+    assert.equal(toks[2].start.line, 3)
+  })
+
+  it('treats quoted strings as single tokens with correct start position', () => {
+    const toks = tokenizeWithPositions('id "hello world"')
+    assert.equal(toks[1].value, '"hello world"')
+    assert.equal(toks[1].start.line, 1)
+    assert.equal(toks[1].start.col, 4)
+    assert.equal(toks[1].start.offset, 3)
+  })
+
+  it('treats brace blocks as single tokens', () => {
+    const toks = tokenizeWithPositions('id { a b }')
+    assert.equal(toks[1].value, '{ a b }')
+    assert.equal(toks[1].start.col, 4)
+  })
+
+  it('skips comments without affecting token positions', () => {
+    const toks = tokenizeWithPositions('// comment\nid value')
+    assert.equal(toks[0].value, 'id')
+    assert.equal(toks[0].start.line, 2)
+    assert.equal(toks[0].start.col, 1)
+    assert.equal(toks[0].start.offset, 11)
+  })
+
+  it('records end position immediately after the last char of value', () => {
+    const toks = tokenizeWithPositions('aaa bbb')
+    assert.equal(toks[0].end.line, 1)
+    assert.equal(toks[0].end.col, 4)
+    assert.equal(toks[0].end.offset, 3)
+  })
+})


### PR DESCRIPTION
Closes P0-2 and P2-3 from TODO.primmel.

## Position tracking

`tokenizeWithPositions()` returns `Token[]` where each token carries `{ value, start, end }` with 1-based line, column, and 0-based offset. Tokenization rules (comments, quoted strings, brace blocks, escapes) match the legacy `tokenize()` exactly. `tokenize()` now delegates to it (DRY).

`parse()` uses positioned tokens internally so every thrown error now says `line X col Y` instead of `token N`.

`ValidationIssue` gains optional `position?: Position` — parse-time issues always populate it.

## Duplicate-ID detection

`ParserConfiguration` entries gain `field?: keyof ParseContext` declaring which collection the keyword writes to.

`parse.ts` tracks IDs per field via `Map<field, Map<id, Position>>`. On second occurrence, emits a `duplicate-id` `ValidationIssue` with position of both declarations. Cross-kind collisions (e.g. a Role and a Process sharing 'widget') are NOT flagged — only same-kind.

Issues collected on `ParseContext.issues`. Surface via new `loadWithIssues()` / `loadFileWithIssues()`.

## Post-resolution validation

`validate.ts` adds post-resolution checks: `form-calculation-missing`, `form-subform-missing`, `form-conformance-process-missing`, `empty-id`, `state-machine-{from,to}-missing`.

## New public API

- `loadWithIssues(src)` / `loadFileWithIssues(path)`: returns `{ standard, issues }`
- `validate(standard)`: returns `ValidationIssue[]`
- Types: `Token`, `Position`, `ValidationIssue`, `ValidationSeverity`

## Tests

12 new tests (positions: 7, duplicate-detection: 5). All 79 pass.

## Known downstream bugs surfaced

When run against the R 60 model, `validate()` reports 24 real form-parser bugs (conformance_process / calculation field references mangled by `removePackage` in form.ts). These existed before; the validator just makes them visible. Fix is on a separate branch.