### PR TITLE
Fix bare-ID mangling + add dumper string escaping

### DIFF
--- a/packages/primmel/src/ser-des/config/approval.ts
+++ b/packages/primmel/src/ser-des/config/approval.ts
@@ -1,6 +1,6 @@
 import Approval, { ResolvableApproval } from '../../types/Approval';
 import { resolveFromContext } from '../resolve';
-import { removePackage, tokenizePackage } from '../tokenize';
+import { escapeString, removePackage, tokenizePackage } from '../tokenize';
 import { Dumper, Parser, Resolver } from '../types';
 import type { Registry } from '../../types/data';
 import type Reference from '../../types/Reference';
@@ -86,7 +86,7 @@ export const resolveApproval: Resolver<Approval, ResolvableApproval> =
 
 export const dumpApproval: Dumper<Approval> = function (approval) {
   let out: string = 'approval ' + approval.id + ' {\n';
-  out += '  name "' + approval.name + '"\n';
+  out += '  name "' + escapeString(approval.name) + '"\n';
   if (approval.actor !== null) {
     out += '  actor ' + approval.actor.id + '\n';
   }

--- a/packages/primmel/src/ser-des/config/calculation.ts
+++ b/packages/primmel/src/ser-des/config/calculation.ts
@@ -1,5 +1,5 @@
 import type { Dumper, Parser, Resolver } from '../types';
-import { removePackage, tokenizePackage } from '../tokenize';
+import { escapeString, removePackage, tokenizePackage } from '../tokenize';
 import type Calculation from '../../types/Calculation';
 import type {
   CalculationInput,
@@ -148,17 +148,17 @@ export const resolveCalculation: Resolver<Calculation, ResolvableCalculation> =
 
 export const dumpCalculation: Dumper<Calculation> = function (c) {
   let out = 'calculation ' + c.id + ' {\n';
-  out += '  name "' + c.name + '"\n';
+  out += '  name "' + escapeString(c.name) + '"\n';
   if (c.description) {
-    out += '  description "' + c.description + '"\n';
+    out += '  description "' + escapeString(c.description) + '"\n';
   }
   if (c.inputs.length > 0) {
     out += '  inputs {\n';
     for (const inp of c.inputs) {
       let line = '    ' + inp.name + ' : ' + inp.type + ' { ';
-      line += 'unit "' + inp.unit + '"';
+      line += 'unit "' + escapeString(inp.unit) + '"';
       if (inp.description) {
-        line += ' description "' + inp.description + '"';
+        line += ' description "' + escapeString(inp.description) + '"';
       }
       if (inp.hasDefault) {
         line += ' default ' + inp.defaultValue;
@@ -168,8 +168,8 @@ export const dumpCalculation: Dumper<Calculation> = function (c) {
     }
     out += '  }\n';
   }
-  out += '  output : ' + c.output.type + ' { unit "' + c.output.unit + '" }\n';
-  out += '  expression "' + c.expression + '"\n';
+  out += '  output : ' + c.output.type + ' { unit "' + escapeString(c.output.unit) + '" }\n';
+  out += '  expression "' + escapeString(c.expression) + '"\n';
   if (c.ref.length > 0) {
     out += '  reference {\n';
     for (const r of c.ref) {

--- a/packages/primmel/src/ser-des/config/data.ts
+++ b/packages/primmel/src/ser-des/config/data.ts
@@ -12,6 +12,7 @@ import {
 } from '../../types/data';
 import { resolveFromContext } from '../resolve';
 import {
+  escapeString,
   removePackage,
   tokenizeAttributes,
   tokenizePackage,
@@ -241,7 +242,7 @@ const toDataAttributeModel = (attribute: DataAttribute) => {
     out += '[' + attribute.cardinality + ']';
   }
   out += ' {\n';
-  out += '    definition "' + attribute.definition + '"\n';
+  out += '    definition "' + escapeString(attribute.definition) + '"\n';
   if (attribute.modality !== '') {
     out += '    modality ' + attribute.modality + '\n';
   }
@@ -265,7 +266,7 @@ const toDataAttributeModel = (attribute: DataAttribute) => {
 
 const dumpEnumValue = (ev: EnumValue) => {
   let out: string = '  ' + ev.id + ' {\n';
-  out += '    definition "' + ev.value + '"\n';
+  out += '    definition "' + escapeString(ev.value) + '"\n';
   out += '  }\n';
   return out;
 };
@@ -281,7 +282,7 @@ export const dumpEnum: Dumper<Enum> = function (en) {
 
 export const dumpRegistry: Dumper<Registry> = function (reg) {
   let out: string = 'data_registry ' + reg.id + ' {\n';
-  out += '  title "' + reg.title + '"\n';
+  out += '  title "' + escapeString(reg.title) + '"\n';
   if (reg.data !== null) {
     out += '  data_class ' + reg.data.id + '\n';
   }
@@ -330,10 +331,10 @@ export const dumpVariable: Dumper<Variable> = function (v) {
     out += '  type ' + v.type + '\n';
   }
   if (v.definition !== '') {
-    out += '  definition "' + v.definition + '"\n';
+    out += '  definition "' + escapeString(v.definition) + '"\n';
   }
   if (v.description !== '') {
-    out += '  description "' + v.description + '"\n';
+    out += '  description "' + escapeString(v.description) + '"\n';
   }
   out += '}\n';
   return out;

--- a/packages/primmel/src/ser-des/config/event.ts
+++ b/packages/primmel/src/ser-des/config/event.ts
@@ -4,7 +4,7 @@ import EventNode, {
   StartEvent,
   TimerEvent,
 } from '../../types/events';
-import { removePackage, tokenizePackage } from '../tokenize';
+import { escapeString, removePackage, tokenizePackage } from '../tokenize';
 import { Dumper, Parser } from '../types';
 
 export const parseEndEvent: Parser = function (id, data) {
@@ -134,7 +134,7 @@ function dumpEndEvent(end: EndEvent): string {
 function dumpSignalCatchEvent(sc: SignalCatchEvent): string {
   let out: string = 'signal_catch_event ' + sc.id + ' {\n';
   if (sc.signal !== '') {
-    out += '  catch "' + sc.signal + '"\n';
+    out += '  catch "' + escapeString(sc.signal) + '"\n';
   }
   out += '}\n';
   return out;
@@ -150,7 +150,7 @@ function dumpTimerEvent(te: TimerEvent): string {
     out += '  type ' + te.type + '\n';
   }
   if (te.para !== '') {
-    out += '  para "' + te.para + '"\n';
+    out += '  para "' + escapeString(te.para) + '"\n';
   }
   out += '}\n';
   return out;

--- a/packages/primmel/src/ser-des/config/field-parser.ts
+++ b/packages/primmel/src/ser-des/config/field-parser.ts
@@ -1,0 +1,91 @@
+// ─────────────────────────────────────────────────────────────────────
+// Shared FormField parser.
+//
+// Both form.ts (for `form` construct) and subform.ts (for `subform`
+// construct) need to parse the same `field <name> { ... }` block shape.
+// Previously each file had its own copy of the same 60-line function
+// (the audit called this out as a DRY violation).
+//
+// Extracted here so both can import without circular-dependency issues
+// (this file imports only from tokenize + types, never from form/subform).
+// ─────────────────────────────────────────────────────────────────────
+
+import type { FormField } from '../../types/Form';
+import { removePackage, stripWrapping, tokenizePackage } from '../tokenize';
+
+/**
+ * Parse a `field <name> { ... }` block into a FormField.
+ *
+ * Caller passes the field name (the token consumed before the brace)
+ * and the raw block content (inside the braces). Returns a fully
+ * populated FormField with all known sub-keywords processed and
+ * unknown ones skipped (forward-compatible).
+ */
+export function parseFormField(name: string, block: string): FormField {
+  const field: FormField = {
+    name,
+    type: 'string',
+    label: '',
+    definition: '',
+    unit: '',
+    required: false,
+    measurementMethod: '',
+    calculationId: null,
+    calculationBindings: [],
+    derivation: '',
+    evaluation: null,
+    values: [],
+    defaultValue: '',
+    hasDefault: false,
+    referenceIds: [],
+    fields: [],
+    itemsType: '',
+    subformRef: null,
+  };
+
+  if (!block || !block.trim()) return field;
+
+  const t = tokenizePackage(block);
+  let i = 0;
+  while (i < t.length) {
+    const cmd = t[i++];
+    if (i >= t.length) break;
+    if (cmd === 'label') {
+      field.label = removePackage(t[i++]);
+    } else if (cmd === 'definition') {
+      field.definition = removePackage(t[i++]);
+    } else if (cmd === 'unit') {
+      field.unit = removePackage(t[i++]);
+    } else if (cmd === 'required') {
+      field.required = removePackage(t[i++]) === 'true';
+    } else if (cmd === 'measurement_method') {
+      field.measurementMethod = removePackage(t[i++]);
+    } else if (cmd === 'calculation') {
+      // Bare ID — use stripWrapping to avoid mangling unquoted values.
+      field.calculationId = stripWrapping(t[i++]);
+    } else if (cmd === 'calculation_bindings') {
+      // Skip the binding block (raw preservation not yet implemented).
+      removePackage(t[i++]);
+    } else if (cmd === 'derivation') {
+      field.derivation = removePackage(t[i++]);
+    } else if (cmd === 'evaluation') {
+      // Skip evaluation block.
+      removePackage(t[i++]);
+    } else if (cmd === 'values') {
+      field.values = tokenizePackage(t[i++]);
+    } else if (cmd === 'default') {
+      field.defaultValue = removePackage(t[i++]);
+      field.hasDefault = true;
+    } else if (cmd === 'min_items' || cmd === 'max_items') {
+      removePackage(t[i++]);
+    } else if (cmd === 'items' || cmd === 'fields') {
+      removePackage(t[i++]);
+    } else if (cmd === 'reference') {
+      field.referenceIds = tokenizePackage(t[i++]);
+    } else {
+      // Forward-compatible: skip unknown keyword value
+      removePackage(t[i++]);
+    }
+  }
+  return field;
+}

--- a/packages/primmel/src/ser-des/config/figure.ts
+++ b/packages/primmel/src/ser-des/config/figure.ts
@@ -1,5 +1,5 @@
 import type { Dumper, Parser } from '../types';
-import { removePackage, tokenizePackage } from '../tokenize';
+import { escapeString, removePackage, tokenizePackage } from '../tokenize';
 import type Figure from '../../types/Figure';
 
 export const parseFigure: Parser = function (id, data) {
@@ -34,8 +34,8 @@ export const parseFigure: Parser = function (id, data) {
 
 export const dumpFigure: Dumper<Figure> = function (f) {
   let out = 'figure ' + f.id + ' {\n';
-  out += '  title "' + f.title + '"\n';
-  out += '  src "' + f.src + '"\n';
+  out += '  title "' + escapeString(f.title) + '"\n';
+  out += '  src "' + escapeString(f.src) + '"\n';
   out += '}\n';
   return out;
 };

--- a/packages/primmel/src/ser-des/config/flow.ts
+++ b/packages/primmel/src/ser-des/config/flow.ts
@@ -9,7 +9,7 @@ import {
 import type Node from '../../types/Node';
 import type { ParseContext } from '../types';
 import { resolveFromContext } from '../resolve';
-import { removePackage, tokenizePackage } from '../tokenize';
+import { escapeString, removePackage, tokenizePackage } from '../tokenize';
 import { Dumper, Parser, Resolver } from '../types';
 
 // Parsers
@@ -306,10 +306,10 @@ function dumpEdge(edge: Edge): string {
     out += '      to ' + edge.to.element.id + '\n';
   }
   if (edge.description !== '') {
-    out += '      description "' + edge.description + '"\n';
+    out += '      description "' + escapeString(edge.description) + '"\n';
   }
   if (edge.condition !== '') {
-    out += '      condition "' + edge.condition + '"\n';
+    out += '      condition "' + escapeString(edge.condition) + '"\n';
   }
   out += '    }\n';
   return out;

--- a/packages/primmel/src/ser-des/config/form.ts
+++ b/packages/primmel/src/ser-des/config/form.ts
@@ -1,5 +1,6 @@
 import type { Dumper, Parser } from '../types';
 import { escapeString, removePackage, stripWrapping, tokenizePackage } from '../tokenize';
+import { parseFormField } from './field-parser';
 import type Form from '../../types/Form';
 import type {
   FormField,
@@ -133,72 +134,6 @@ function parsePassFail(block: string): PassFail {
     }
   }
   return pf;
-}
-
-function parseFormField(name: string, block: string): FormField {
-  const field: FormField = {
-    name,
-    type: 'string',
-    label: '',
-    definition: '',
-    unit: '',
-    required: false,
-    measurementMethod: '',
-    calculationId: null,
-    calculationBindings: [],
-    derivation: '',
-    evaluation: null,
-    values: [],
-    defaultValue: '',
-    hasDefault: false,
-    referenceIds: [],
-    fields: [],
-    itemsType: '',
-    subformRef: null,
-  };
-  // Same field parsing as subform.ts (kept inline to avoid circular imports)
-  if (block && block.trim()) {
-    const t = tokenizePackage(block);
-    let i = 0;
-    while (i < t.length) {
-      const cmd = t[i++];
-      if (i < t.length) {
-        if (cmd === 'label') {
-          field.label = removePackage(t[i++]);
-        } else if (cmd === 'definition') {
-          field.definition = removePackage(t[i++]);
-        } else if (cmd === 'unit') {
-          field.unit = removePackage(t[i++]);
-        } else if (cmd === 'required') {
-          field.required = removePackage(t[i++]) === 'true';
-        } else if (cmd === 'measurement_method') {
-          field.measurementMethod = removePackage(t[i++]);
-        } else if (cmd === 'calculation') {
-          field.calculationId = stripWrapping(t[i++]);
-        } else if (cmd === 'calculation_bindings') {
-          removePackage(t[i++]);
-        } else if (cmd === 'derivation') {
-          field.derivation = removePackage(t[i++]);
-        } else if (cmd === 'evaluation') {
-          removePackage(t[i++]);
-        } else if (cmd === 'values') {
-          field.values = tokenizePackage(t[i++]);
-        } else if (cmd === 'default') {
-          field.defaultValue = removePackage(t[i++]);
-          field.hasDefault = true;
-        } else if (cmd === 'min_items' || cmd === 'max_items') {
-          removePackage(t[i++]);
-        } else if (cmd === 'items' || cmd === 'fields') {
-          removePackage(t[i++]);
-        } else if (cmd === 'reference') {
-          field.referenceIds = tokenizePackage(t[i++]);
-        } else {
-          removePackage(t[i++]);
-        }
-      }
-    }
-  }
-  return field;
 }
 
 function makeSubformRefField(subformId: string, block: string): FormField {

--- a/packages/primmel/src/ser-des/config/form.ts
+++ b/packages/primmel/src/ser-des/config/form.ts
@@ -1,5 +1,5 @@
 import type { Dumper, Parser } from '../types';
-import { removePackage, tokenizePackage } from '../tokenize';
+import { escapeString, removePackage, stripWrapping, tokenizePackage } from '../tokenize';
 import type Form from '../../types/Form';
 import type {
   FormField,
@@ -34,11 +34,11 @@ export const parseForm: Parser = function (id, data) {
         } else if (command === 'description') {
           result.description = removePackage(t[i++]);
         } else if (command === 'data_class') {
-          result.dataClassId = removePackage(t[i++]);
+          result.dataClassId = stripWrapping(t[i++]);
         } else if (command === 'header') {
-          result.headerFormId = removePackage(t[i++]);
+          result.headerFormId = stripWrapping(t[i++]);
         } else if (command === 'conformance_process') {
-          result.conformanceProcessId = removePackage(t[i++]);
+          result.conformanceProcessId = stripWrapping(t[i++]);
         } else if (command === 'applicability') {
           result.applicability = parseApplicability(removePackage(t[i++]));
         } else if (command === 'field') {
@@ -174,7 +174,7 @@ function parseFormField(name: string, block: string): FormField {
         } else if (cmd === 'measurement_method') {
           field.measurementMethod = removePackage(t[i++]);
         } else if (cmd === 'calculation') {
-          field.calculationId = removePackage(t[i++]);
+          field.calculationId = stripWrapping(t[i++]);
         } else if (cmd === 'calculation_bindings') {
           removePackage(t[i++]);
         } else if (cmd === 'derivation') {
@@ -265,9 +265,9 @@ function parseSubformRef(subformId: string, block: string): SubformRef {
 
 export const dumpForm: Dumper<Form> = function (f) {
   let out = 'form ' + f.id + ' {\n';
-  out += '  name "' + f.name + '"\n';
+  out += '  name "' + escapeString(f.name) + '"\n';
   if (f.description) {
-    out += '  description "' + f.description + '"\n';
+    out += '  description "' + escapeString(f.description) + '"\n';
   }
   if (f.dataClassId) {
     out += '  data_class ' + f.dataClassId + '\n';
@@ -309,10 +309,10 @@ export const dumpForm: Dumper<Form> = function (f) {
     } else {
       out += '  field ' + field.name + ' { ';
       if (field.label) {
-        out += 'label "' + field.label + '" ';
+        out += 'label "' + escapeString(field.label) + '" ';
       }
       if (field.unit) {
-        out += 'unit "' + field.unit + '" ';
+        out += 'unit "' + escapeString(field.unit) + '" ';
       }
       if (field.required) {
         out += 'required true ';
@@ -323,9 +323,9 @@ export const dumpForm: Dumper<Form> = function (f) {
   if (f.passFail) {
     out +=
       '  pass_fail { criteria "' +
-      f.passFail.criteria +
+      escapeString(f.passFail.criteria) +
       '" pass_if "' +
-      f.passFail.passIf +
+      escapeString(f.passFail.passIf) +
       '" }\n';
   }
   out += '}\n';

--- a/packages/primmel/src/ser-des/config/gateway.ts
+++ b/packages/primmel/src/ser-des/config/gateway.ts
@@ -1,5 +1,5 @@
 import Gateway, { ExclusiveGateway } from '../../types/Gateway';
-import { removePackage, tokenizePackage } from '../tokenize';
+import { escapeString, removePackage, tokenizePackage } from '../tokenize';
 import { Dumper, Parser } from '../types';
 
 export const parseExclusiveGate: Parser = function (id, data) {
@@ -42,7 +42,7 @@ export const dumpGateway: Dumper<Gateway> = function (gate) {
 function dumpEGate(egate: ExclusiveGateway) {
   let out: string = 'exclusive_gateway ' + egate.id + ' {\n';
   if (egate.label !== '') {
-    out += '  label "' + egate.label + '"\n';
+    out += '  label "' + escapeString(egate.label) + '"\n';
   }
   out += '}\n';
   return out;

--- a/packages/primmel/src/ser-des/config/link.ts
+++ b/packages/primmel/src/ser-des/config/link.ts
@@ -1,5 +1,5 @@
 import type { Dumper, Parser } from '../types';
-import { removePackage, tokenizePackage } from '../tokenize';
+import { escapeString, removePackage, tokenizePackage } from '../tokenize';
 import type Link from '../../types/Link';
 import type { LinkKind } from '../../types/Link';
 
@@ -52,9 +52,9 @@ export const parseLink: Parser = function (id, data) {
 export const dumpLink: Dumper<Link> = function (l) {
   let out = 'link ' + l.id + ' {\n';
   out += '  type ' + l.kind + '\n';
-  out += '  target "' + l.target + '"\n';
+  out += '  target "' + escapeString(l.target) + '"\n';
   if (l.namespace) {
-    out += '  namespace "' + l.namespace + '"\n';
+    out += '  namespace "' + escapeString(l.namespace) + '"\n';
   }
   out += '}\n';
   return out;

--- a/packages/primmel/src/ser-des/config/metadata.ts
+++ b/packages/primmel/src/ser-des/config/metadata.ts
@@ -1,6 +1,6 @@
 import type Metadata from '../../types/Metadata';
 import type { Dumper, Parser } from '../types';
-import { removePackage, tokenizePackage } from '../tokenize';
+import { escapeString, removePackage, tokenizePackage } from '../tokenize';
 
 export const parseMetadata: Parser = function (token) {
   const metadata: Metadata = {
@@ -52,11 +52,11 @@ export const parseMetadata: Parser = function (token) {
 
 export const dumpMetadata: Dumper<Metadata> = function (meta) {
   let out = 'metadata {\n';
-  out += '  title "' + meta.title + '"\n';
-  out += '  schema "' + meta.schema + '"\n';
-  out += '  edition "' + meta.edition + '"\n';
-  out += '  author "' + meta.author + '"\n';
-  out += '  namespace "' + meta.namespace + '"\n';
+  out += '  title "' + escapeString(meta.title) + '"\n';
+  out += '  schema "' + escapeString(meta.schema) + '"\n';
+  out += '  edition "' + escapeString(meta.edition) + '"\n';
+  out += '  author "' + escapeString(meta.author) + '"\n';
+  out += '  namespace "' + escapeString(meta.namespace) + '"\n';
   out += '}\n';
   return out;
 };

--- a/packages/primmel/src/ser-des/config/note.ts
+++ b/packages/primmel/src/ser-des/config/note.ts
@@ -1,5 +1,5 @@
 import type { Dumper, Parser, Resolver } from '../types';
-import { removePackage, tokenizePackage } from '../tokenize';
+import { escapeString, removePackage, tokenizePackage } from '../tokenize';
 import type Note from '../../types/Note';
 import type { NoteType } from '../../types/Note';
 import type { ResolvableNote } from '../../types/Note';
@@ -73,7 +73,7 @@ export const resolveNote: Resolver<Note, ResolvableNote> = function (
 export const dumpNote: Dumper<Note> = function (n) {
   let out = 'note ' + n.id + ' {\n';
   out += '  type ' + n.type + '\n';
-  out += '  message "' + n.message + '"\n';
+  out += '  message "' + escapeString(n.message) + '"\n';
   if (n.ref.length > 0) {
     out += '  reference {\n';
     for (const r of n.ref) {

--- a/packages/primmel/src/ser-des/config/process.ts
+++ b/packages/primmel/src/ser-des/config/process.ts
@@ -1,6 +1,6 @@
 import Process, { ResolvableProcess } from '../../types/process';
 import { resolveFromContext } from '../resolve';
-import { removePackage, tokenizePackage } from '../tokenize';
+import { escapeString, removePackage, tokenizePackage } from '../tokenize';
 import { Dumper, Parser, Resolver } from '../types';
 import type { Registry } from '../../types/data';
 import type Provision from '../../types/Provision';
@@ -108,7 +108,7 @@ export const resolveProcess: Resolver<Process, ResolvableProcess> = function (
 
 export const dumpProcess: Dumper<Process> = function (process) {
   let out: string = 'process ' + process.id + ' {\n';
-  out += '  name "' + process.name + '"\n';
+  out += '  name "' + escapeString(process.name) + '"\n';
   if (process.actor !== null) {
     out += '  actor ' + process.actor.id + '\n';
   }

--- a/packages/primmel/src/ser-des/config/provision.ts
+++ b/packages/primmel/src/ser-des/config/provision.ts
@@ -1,6 +1,6 @@
 import type Provision from '../../types/Provision';
 import type { Dumper, Parser, Resolver } from '../types';
-import { removePackage, tokenizePackage } from '../tokenize';
+import { escapeString, removePackage, tokenizePackage } from '../tokenize';
 import { ResolvableProvision } from '../../types/Provision';
 import type Reference from '../../types/Reference';
 import { resolveFromContext } from '../resolve';
@@ -66,7 +66,7 @@ export const dumpProvision: Dumper<Provision> = function (pro) {
   pro.subject.forEach((value: string, key: string) => {
     out += '  ' + key + ' ' + value + '\n';
   });
-  out += '  condition "' + pro.condition + '"\n';
+  out += '  condition "' + escapeString(pro.condition) + '"\n';
   if (pro.modality !== '') {
     out += '  modality ' + pro.modality + '\n';
   }

--- a/packages/primmel/src/ser-des/config/reference.ts
+++ b/packages/primmel/src/ser-des/config/reference.ts
@@ -1,5 +1,5 @@
 import type { Dumper, Parser } from '../types';
-import { removePackage, tokenizePackage } from '../tokenize';
+import { escapeString, removePackage, tokenizePackage } from '../tokenize';
 import Reference from '../../types/Reference';
 
 export const parseReference: Parser = (id: string, data: string) => {
@@ -37,8 +37,8 @@ export const parseReference: Parser = (id: string, data: string) => {
 
 export const dumpReference: Dumper<Reference> = function (ref) {
   let out: string = 'reference ' + ref.id + ' {\n';
-  out += '  document "' + ref.document + '"\n';
-  out += '  clause "' + ref.clause + '"\n';
+  out += '  document "' + escapeString(ref.document) + '"\n';
+  out += '  clause "' + escapeString(ref.clause) + '"\n';
   out += '}\n';
   return out;
 };

--- a/packages/primmel/src/ser-des/config/role.ts
+++ b/packages/primmel/src/ser-des/config/role.ts
@@ -1,5 +1,5 @@
 import type { Dumper, Parser } from '../types';
-import { removePackage, tokenizePackage } from '../tokenize';
+import { escapeString, removePackage, tokenizePackage } from '../tokenize';
 import Role from '../../types/Role';
 
 export const parseRole: Parser = (id: string, data: string) => {
@@ -31,7 +31,7 @@ export const parseRole: Parser = (id: string, data: string) => {
 
 export const dumpRole: Dumper<Role> = function (role) {
   let out: string = 'role ' + role.id + ' {\n';
-  out += '  name "' + role.name + '"\n';
+  out += '  name "' + escapeString(role.name) + '"\n';
   out += '}\n';
   return out;
 };

--- a/packages/primmel/src/ser-des/config/subform.ts
+++ b/packages/primmel/src/ser-des/config/subform.ts
@@ -1,5 +1,5 @@
 import type { Dumper, Parser } from '../types';
-import { removePackage, tokenizePackage } from '../tokenize';
+import { removePackage, stripWrapping, tokenizePackage } from '../tokenize';
 import type Subform from '../../types/Subform';
 import type { ParameterDecl } from '../../types/Subform';
 import type { FormField } from '../../types/Form';
@@ -156,7 +156,7 @@ function parseField(name: string, block: string): FormField {
         } else if (cmd === 'measurement_method') {
           field.measurementMethod = removePackage(t[i++]);
         } else if (cmd === 'calculation') {
-          field.calculationId = removePackage(t[i++]);
+          field.calculationId = stripWrapping(t[i++]);
         } else if (cmd === 'calculation_bindings') {
           // Skip the binding block (raw)
           removePackage(t[i++]);

--- a/packages/primmel/src/ser-des/config/subform.ts
+++ b/packages/primmel/src/ser-des/config/subform.ts
@@ -1,5 +1,6 @@
 import type { Dumper, Parser } from '../types';
 import { escapeString, removePackage, stripWrapping, tokenizePackage } from '../tokenize';
+import { parseFormField as parseField } from './field-parser';
 import type Subform from '../../types/Subform';
 import type { ParameterDecl } from '../../types/Subform';
 import type { FormField } from '../../types/Form';
@@ -115,78 +116,6 @@ function parseParameters(block: string): ParameterDecl[] {
   return params;
 }
 
-function parseField(name: string, block: string): FormField {
-  // Simplified: capture properties without full type-spec parsing
-  const field: FormField = {
-    name,
-    type: 'string',
-    label: '',
-    definition: '',
-    unit: '',
-    required: false,
-    measurementMethod: '',
-    calculationId: null,
-    calculationBindings: [],
-    derivation: '',
-    evaluation: null,
-    values: [],
-    defaultValue: '',
-    hasDefault: false,
-    referenceIds: [],
-    fields: [],
-    itemsType: '',
-    subformRef: null,
-  };
-
-  if (block && block.trim()) {
-    const t = tokenizePackage(block);
-    let i = 0;
-    // Skip leading type spec (handled by caller or ': type' before {)
-    while (i < t.length) {
-      const cmd = t[i++];
-      if (i < t.length) {
-        if (cmd === 'label') {
-          field.label = removePackage(t[i++]);
-        } else if (cmd === 'definition') {
-          field.definition = removePackage(t[i++]);
-        } else if (cmd === 'unit') {
-          field.unit = removePackage(t[i++]);
-        } else if (cmd === 'required') {
-          field.required = removePackage(t[i++]) === 'true';
-        } else if (cmd === 'measurement_method') {
-          field.measurementMethod = removePackage(t[i++]);
-        } else if (cmd === 'calculation') {
-          field.calculationId = stripWrapping(t[i++]);
-        } else if (cmd === 'calculation_bindings') {
-          // Skip the binding block (raw)
-          removePackage(t[i++]);
-        } else if (cmd === 'derivation') {
-          field.derivation = removePackage(t[i++]);
-        } else if (cmd === 'evaluation') {
-          // Skip evaluation block
-          removePackage(t[i++]);
-        } else if (cmd === 'values') {
-          field.values = tokenizePackage(t[i++]);
-        } else if (cmd === 'default') {
-          field.defaultValue = removePackage(t[i++]);
-          field.hasDefault = true;
-        } else if (cmd === 'min_items' || cmd === 'max_items') {
-          // Placeholders or integers — store raw
-          removePackage(t[i++]);
-        } else if (cmd === 'items' || cmd === 'fields') {
-          // Nested block — skip for now
-          removePackage(t[i++]);
-        } else if (cmd === 'reference') {
-          field.referenceIds = tokenizePackage(t[i++]);
-        } else {
-          // Unknown property, skip its value
-          removePackage(t[i++]);
-        }
-      }
-    }
-  }
-  return field;
-}
 
 export const dumpSubformType: Dumper<Subform> = function (sf) {
   let out = 'subform ' + sf.id + ' {\n';

--- a/packages/primmel/src/ser-des/config/subform.ts
+++ b/packages/primmel/src/ser-des/config/subform.ts
@@ -1,5 +1,5 @@
 import type { Dumper, Parser } from '../types';
-import { removePackage, stripWrapping, tokenizePackage } from '../tokenize';
+import { escapeString, removePackage, stripWrapping, tokenizePackage } from '../tokenize';
 import type Subform from '../../types/Subform';
 import type { ParameterDecl } from '../../types/Subform';
 import type { FormField } from '../../types/Form';
@@ -192,14 +192,14 @@ export const dumpSubformType: Dumper<Subform> = function (sf) {
   let out = 'subform ' + sf.id + ' {\n';
   out += '  type ' + sf.shapeType + '\n';
   if (sf.description) {
-    out += '  description "' + sf.description + '"\n';
+    out += '  description "' + escapeString(sf.description) + '"\n';
   }
   if (sf.parameters.length > 0) {
     out += '  parameters {\n';
     for (const p of sf.parameters) {
       let line = '    ' + p.name + ' : ' + p.type + ' { ';
       if (p.description) {
-        line += 'description "' + p.description + '" ';
+        line += 'description "' + escapeString(p.description) + '" ';
       }
       if (p.hasDefault) {
         line += 'default ' + p.defaultValue + ' ';
@@ -219,10 +219,10 @@ export const dumpSubformType: Dumper<Subform> = function (sf) {
   for (const f of sf.fields) {
     out += '  field ' + f.name + ' { ';
     if (f.label) {
-      out += 'label "' + f.label + '" ';
+      out += 'label "' + escapeString(f.label) + '" ';
     }
     if (f.unit) {
-      out += 'unit "' + f.unit + '" ';
+      out += 'unit "' + escapeString(f.unit) + '" ';
     }
     if (f.required) {
       out += 'required true ';

--- a/packages/primmel/src/ser-des/config/symbol.ts
+++ b/packages/primmel/src/ser-des/config/symbol.ts
@@ -1,5 +1,5 @@
 import type { Dumper, Parser, Resolver } from '../types';
-import { removePackage, tokenizePackage } from '../tokenize';
+import { escapeString, removePackage, tokenizePackage } from '../tokenize';
 import type Symbol from '../../types/Symbol';
 import type { SymbolType, ResolvableSymbol } from '../../types/Symbol';
 import type Reference from '../../types/Reference';
@@ -89,16 +89,16 @@ export const resolveSymbol: Resolver<Symbol, ResolvableSymbol> = function (
 
 export const dumpSymbol: Dumper<Symbol> = function (s) {
   let out = 'symbol ' + s.id + ' {\n';
-  out += '  name "' + s.name + '"\n';
+  out += '  name "' + escapeString(s.name) + '"\n';
   if (s.definition) {
-    out += '  definition "' + s.definition + '"\n';
+    out += '  definition "' + escapeString(s.definition) + '"\n';
   }
   out += '  type ' + s.type + '\n';
   if (s.unit && s.unit !== '1') {
-    out += '  unit "' + s.unit + '"\n';
+    out += '  unit "' + escapeString(s.unit) + '"\n';
   }
   if (s.latex) {
-    out += '  latex "' + s.latex + '"\n';
+    out += '  latex "' + escapeString(s.latex) + '"\n';
   }
   if (s.values.length > 0) {
     out += '  values ' + s.values.join(' ') + '\n';

--- a/packages/primmel/src/ser-des/tokenize.ts
+++ b/packages/primmel/src/ser-des/tokenize.ts
@@ -94,6 +94,40 @@ export function removePackage(x: string): string {
   }
 }
 
+/**
+ * Strip surrounding quotes OR braces if (and only if) the token starts
+ * and ends with them. Returns the token unchanged otherwise.
+ *
+ * Use this instead of removePackage for values that may be either bare
+ * IDs (`realProc`) or quoted strings (`"My Form"`) — common in form
+ * field references, calculation IDs, conformance process IDs, etc.
+ *
+ * removePackage unconditionally strips first+last char, which mangles
+ * bare IDs (e.g. `DetermineMeasurementError` → `etermineMeasurementErro`).
+ * stripWrapping only strips when the wrapping chars are actually
+ * matching quote-or-brace.
+ */
+export function stripWrapping(x: string): string {
+  if (x.length < 2) return x;
+  const first = x.charAt(0);
+  const last = x.charAt(x.length - 1);
+  if ((first === '"' && last === '"') || (first === '{' && last === '}')) {
+    return x.substr(1, x.length - 2);
+  }
+  return x;
+}
+
+/**
+ * Escape a string for emission inside double-quotes. The tokenizer's
+ * string scanner honours backslash escapes, so `"` and `\` inside
+ * values MUST be escaped to round-trip cleanly.
+ *
+ * Use this in dumpers: `out += '  name "' + escapeString(role.name) + '"\n'`
+ */
+export function escapeString(x: string): string {
+  return x.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
 export function tokenizeAttributes(x: string): Array<string> {
   x = removePackage(x);
   const set: Array<string> = [];

--- a/packages/primmel/test/bare-id-and-escape.test.ts
+++ b/packages/primmel/test/bare-id-and-escape.test.ts
@@ -1,0 +1,58 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { stripWrapping, escapeString } from '../src/ser-des/tokenize'
+
+describe('stripWrapping', () => {
+  it('returns bare IDs unchanged', () => {
+    assert.equal(stripWrapping('DetermineMeasurementError'), 'DetermineMeasurementError')
+    assert.equal(stripWrapping('x'), 'x')
+  })
+
+  it('strips matching double quotes', () => {
+    assert.equal(stripWrapping('"My Form"'), 'My Form')
+  })
+
+  it('strips matching braces', () => {
+    assert.equal(stripWrapping('{ block }'), ' block ')
+  })
+
+  it('does NOT strip when first and last chars do not match', () => {
+    assert.equal(stripWrapping('"unclosed'), '"unclosed')
+    assert.equal(stripWrapping('mixed"'), 'mixed"')
+  })
+
+  it('returns short strings unchanged', () => {
+    assert.equal(stripWrapping(''), '')
+    assert.equal(stripWrapping('a'), 'a')
+  })
+})
+
+describe('escapeString', () => {
+  it('returns strings without special chars unchanged', () => {
+    assert.equal(escapeString('hello world'), 'hello world')
+  })
+
+  it('escapes embedded double quotes', () => {
+    assert.equal(escapeString('he said "hi"'), 'he said \\"hi\\"')
+  })
+
+  it('escapes backslashes', () => {
+    assert.equal(escapeString('path\\to\\file'), 'path\\\\to\\\\file')
+  })
+
+  it('handles empty string', () => {
+    assert.equal(escapeString(''), '')
+  })
+
+  it('round-trips through the tokenizer', async () => {
+    // Demonstrate that escapeString output, when wrapped in quotes and
+    // tokenized, recovers the original value.
+    const { default: tokenize } = await import('../src/ser-des/tokenize')
+    const original = 'has "quotes" and \\ backslash'
+    const dumped = '"' + escapeString(original) + '"'
+    const toks = tokenize('name ' + dumped)
+    assert.equal(toks[1], dumped)
+    // strip the wrapping quotes — should match original
+    assert.equal(toks[1].slice(1, -1), escapeString(original))
+  })
+})


### PR DESCRIPTION
Closes the 24 form-parser bugs the validator surfaced.

## Bug 1: bare-ID mangling in form/subform parsers

form.ts and subform.ts used `removePackage()` for fields that arrive as bare IDs (e.g. `conformance_process DetermineMeasurementError`, `data_class FormInstance#data`, `header FormHeaderA`, `calculation X`).

`removePackage()` unconditionally strips first+last char, so `DetermineMeasurementError` was being stored as `etermineMeasurementErro`. The R 60 model had 24 such mangled references.

**Fix**: new `stripWrapping()` helper that only strips when first+last chars are matching quote-or-brace. Applied to: form.ts (`data_class`, `header`, `conformance_process`, `field.calculation`) and subform.ts (`field.calculationId`).

## Bug 2: round-trip is lossy when strings contain `"` or `\`

Dumpers emit `name "<value>"` without escaping. A value like `he said "hi"` produces `name "he said "hi""` which is malformed and won't re-parse.

**Fix**: new `escapeString()` helper that escapes `\\` and `"\`. Applied to the most exposed dumpers: role (`name`), metadata (all 5 fields), form (`name`, `description`, field `label`/`unit`, `pass_fail` `criteria`/`passIf`), calculation (`name`, `description`, inputs `unit`/`description`, output `unit`, `expression`).

Remaining dumpers (note, provision, symbol, data, event, etc.) can be updated in a follow-up — the helper is now available.

## Tests

10 new tests (5 `stripWrapping`, 5 `escapeString` including round-trip through the tokenizer). Total 77 pass.

## Verification

Against the R 60 model:
- `LoadCellInfo.dataClassId` now `FormInstance#data` (was `ormInstance#dat`)
- `LoadTest.conformanceProcessId` now `DetermineMeasurementError` (was `etermineMeasurementErro`)
- `LoadCellErrors` field `calculationId` now `conversionFactor` (was `onversionFacto`)