### PR TITLE
Apply lint-fix: prettier formatting + unused imports

### DIFF
--- a/packages/primmel/src/ser-des/config/calculation.ts
+++ b/packages/primmel/src/ser-des/config/calculation.ts
@@ -168,7 +168,12 @@ export const dumpCalculation: Dumper<Calculation> = function (c) {
     }
     out += '  }\n';
   }
-  out += '  output : ' + c.output.type + ' { unit "' + escapeString(c.output.unit) + '" }\n';
+  out +=
+    '  output : ' +
+    c.output.type +
+    ' { unit "' +
+    escapeString(c.output.unit) +
+    '" }\n';
   out += '  expression "' + escapeString(c.expression) + '"\n';
   if (c.ref.length > 0) {
     out += '  reference {\n';

--- a/packages/primmel/src/ser-des/config/field-parser.ts
+++ b/packages/primmel/src/ser-des/config/field-parser.ts
@@ -43,13 +43,17 @@ export function parseFormField(name: string, block: string): FormField {
     subformRef: null,
   };
 
-  if (!block || !block.trim()) return field;
+  if (!block || !block.trim()) {
+    return field;
+  }
 
   const t = tokenizePackage(block);
   let i = 0;
   while (i < t.length) {
     const cmd = t[i++];
-    if (i >= t.length) break;
+    if (i >= t.length) {
+      break;
+    }
     if (cmd === 'label') {
       field.label = removePackage(t[i++]);
     } else if (cmd === 'definition') {

--- a/packages/primmel/src/ser-des/config/form.ts
+++ b/packages/primmel/src/ser-des/config/form.ts
@@ -1,5 +1,10 @@
 import type { Dumper, Parser } from '../types';
-import { escapeString, removePackage, stripWrapping, tokenizePackage } from '../tokenize';
+import {
+  escapeString,
+  removePackage,
+  stripWrapping,
+  tokenizePackage,
+} from '../tokenize';
 import { parseFormField } from './field-parser';
 import type Form from '../../types/Form';
 import type {

--- a/packages/primmel/src/ser-des/config/index.ts
+++ b/packages/primmel/src/ser-des/config/index.ts
@@ -124,7 +124,11 @@ export const PARSER_CONFIG: ParserConfiguration = {
   start_event: { takesID: true, parse: parseStartEvent, field: 'events' },
   end_event: { takesID: true, parse: parseEndEvent, field: 'events' },
   signalcatch: { takesID: true, parse: parseSignalCatchEvent, field: 'events' },
-  signal_catch_event: { takesID: true, parse: parseSignalCatchEvent, field: 'events' },
+  signal_catch_event: {
+    takesID: true,
+    parse: parseSignalCatchEvent,
+    field: 'events',
+  },
   timer: { takesID: true, parse: parseTimerEvent, field: 'events' },
   timer_event: { takesID: true, parse: parseTimerEvent, field: 'events' },
 

--- a/packages/primmel/src/ser-des/config/subform.ts
+++ b/packages/primmel/src/ser-des/config/subform.ts
@@ -1,9 +1,8 @@
 import type { Dumper, Parser } from '../types';
-import { escapeString, removePackage, stripWrapping, tokenizePackage } from '../tokenize';
+import { escapeString, removePackage, tokenizePackage } from '../tokenize';
 import { parseFormField as parseField } from './field-parser';
 import type Subform from '../../types/Subform';
 import type { ParameterDecl } from '../../types/Subform';
-import type { FormField } from '../../types/Form';
 
 export const parseSubform: Parser = function (id, data) {
   const result: Subform = {
@@ -115,7 +114,6 @@ function parseParameters(block: string): ParameterDecl[] {
   }
   return params;
 }
-
 
 export const dumpSubformType: Dumper<Subform> = function (sf) {
   let out = 'subform ' + sf.id + ' {\n';

--- a/packages/primmel/src/ser-des/config/term.ts
+++ b/packages/primmel/src/ser-des/config/term.ts
@@ -27,7 +27,9 @@ export const parseTerm: Parser = function (id, data) {
           // Strip wrapping quotes if present (defensive — most models use bare IDs).
           const raw = t[i++];
           result.symbolId =
-            raw.length >= 2 && raw.charAt(0) === '"' && raw.charAt(raw.length - 1) === '"'
+            raw.length >= 2 &&
+            raw.charAt(0) === '"' &&
+            raw.charAt(raw.length - 1) === '"'
               ? raw.slice(1, -1)
               : raw;
         } else if (command === 'reference') {

--- a/packages/primmel/src/ser-des/tokenize.ts
+++ b/packages/primmel/src/ser-des/tokenize.ts
@@ -89,7 +89,9 @@ export function tokenizeWithPositions(x: string): Token[] {
         }
         value += c;
         advance(1);
-        if (c === '"') break;
+        if (c === '"') {
+          break;
+        }
       }
     } else if (char === '{') {
       let depth = 1;
@@ -109,12 +111,18 @@ export function tokenizeWithPositions(x: string): Token[] {
             }
             value += sc;
             advance(1);
-            if (sc === '"') break;
+            if (sc === '"') {
+              break;
+            }
           }
           continue;
         }
-        if (c === '{') depth++;
-        if (c === '}') depth--;
+        if (c === '{') {
+          depth++;
+        }
+        if (c === '}') {
+          depth--;
+        }
         value += c;
         advance(1);
       }
@@ -164,7 +172,9 @@ export function removePackage(x: string): string {
  * matching quote-or-brace.
  */
 export function stripWrapping(x: string): string {
-  if (x.length < 2) return x;
+  if (x.length < 2) {
+    return x;
+  }
   const first = x.charAt(0);
   const last = x.charAt(x.length - 1);
   if ((first === '"' && last === '"') || (first === '{' && last === '}')) {

--- a/packages/primmel/src/validate.ts
+++ b/packages/primmel/src/validate.ts
@@ -74,7 +74,10 @@ class Validator {
       ...this.standard.processes.map(item => ({ kind: 'process', item })),
       ...this.standard.forms.map(item => ({ kind: 'form', item })),
       ...this.standard.symbols.map(item => ({ kind: 'symbol', item })),
-      ...this.standard.calculations.map(item => ({ kind: 'calculation', item })),
+      ...this.standard.calculations.map(item => ({
+        kind: 'calculation',
+        item,
+      })),
     ];
     for (const { kind, item } of allItems) {
       if (!item.id || item.id.trim() === '') {
@@ -94,7 +97,10 @@ class Validator {
     const subformIds = new Set(this.standard.subforms.map(s => s.id));
 
     for (const form of this.standard.forms) {
-      if (form.conformanceProcessId && !procIds.has(form.conformanceProcessId)) {
+      if (
+        form.conformanceProcessId &&
+        !procIds.has(form.conformanceProcessId)
+      ) {
         this.issue(
           'error',
           'form-conformance-process-missing',

--- a/packages/primmel/test/bare-id-and-escape.test.ts
+++ b/packages/primmel/test/bare-id-and-escape.test.ts
@@ -1,57 +1,64 @@
-import { describe, it } from 'node:test'
-import assert from 'node:assert/strict'
-import { stripWrapping, escapeString, default as tokenize } from '../src/ser-des/tokenize'
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  stripWrapping,
+  escapeString,
+  default as tokenize,
+} from '../src/ser-des/tokenize';
 
 describe('stripWrapping', () => {
   it('returns bare IDs unchanged', () => {
-    assert.equal(stripWrapping('DetermineMeasurementError'), 'DetermineMeasurementError')
-    assert.equal(stripWrapping('x'), 'x')
-  })
+    assert.equal(
+      stripWrapping('DetermineMeasurementError'),
+      'DetermineMeasurementError',
+    );
+    assert.equal(stripWrapping('x'), 'x');
+  });
 
   it('strips matching double quotes', () => {
-    assert.equal(stripWrapping('"My Form"'), 'My Form')
-  })
+    assert.equal(stripWrapping('"My Form"'), 'My Form');
+  });
 
   it('strips matching braces', () => {
-    assert.equal(stripWrapping('{ block }'), ' block ')
-  })
+    assert.equal(stripWrapping('{ block }'), ' block ');
+  });
 
   it('does NOT strip when first and last chars do not match', () => {
-    assert.equal(stripWrapping('"unclosed'), '"unclosed')
-    assert.equal(stripWrapping('mixed"'), 'mixed"')
-  })
+    assert.equal(stripWrapping('"unclosed'), '"unclosed');
+    assert.equal(stripWrapping('mixed"'), 'mixed"');
+  });
 
   it('returns short strings unchanged', () => {
-    assert.equal(stripWrapping(''), '')
-    assert.equal(stripWrapping('a'), 'a')
-  })
-})
+    assert.equal(stripWrapping(''), '');
+    assert.equal(stripWrapping('a'), 'a');
+  });
+});
 
 describe('escapeString', () => {
   it('returns strings without special chars unchanged', () => {
-    assert.equal(escapeString('hello world'), 'hello world')
-  })
+    assert.equal(escapeString('hello world'), 'hello world');
+  });
 
   it('escapes embedded double quotes', () => {
-    assert.equal(escapeString('he said "hi"'), 'he said \\"hi\\"')
-  })
+    assert.equal(escapeString('he said "hi"'), 'he said \\"hi\\"');
+  });
 
   it('escapes backslashes', () => {
-    assert.equal(escapeString('path\\to\\file'), 'path\\\\to\\\\file')
-  })
+    assert.equal(escapeString('path\\to\\file'), 'path\\\\to\\\\file');
+  });
 
   it('handles empty string', () => {
-    assert.equal(escapeString(''), '')
-  })
+    assert.equal(escapeString(''), '');
+  });
 
   it('round-trips through the tokenizer', () => {
     // Demonstrate that escapeString output, when wrapped in quotes and
     // tokenized, recovers the original value.
-    const original = 'has "quotes" and \\ backslash'
-    const dumped = '"' + escapeString(original) + '"'
-    const toks = tokenize('name ' + dumped)
-    assert.equal(toks[1], dumped)
+    const original = 'has "quotes" and \\ backslash';
+    const dumped = '"' + escapeString(original) + '"';
+    const toks = tokenize('name ' + dumped);
+    assert.equal(toks[1], dumped);
     // strip the wrapping quotes — should match original
-    assert.equal(toks[1].slice(1, -1), escapeString(original))
-  })
-})
+    assert.equal(toks[1].slice(1, -1), escapeString(original));
+  });
+});

--- a/packages/primmel/test/duplicate-detection.test.ts
+++ b/packages/primmel/test/duplicate-detection.test.ts
@@ -1,30 +1,30 @@
-import { describe, it } from 'node:test'
-import assert from 'node:assert/strict'
-import { loadWithIssues } from '../src/ser-des/index'
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { loadWithIssues } from '../src/ser-des/index';
 
 describe('duplicate-ID detection (parse-time)', () => {
   it('returns no issues when IDs are unique within a kind', () => {
     const r = loadWithIssues(`
       role author { name "Author" }
       role reviewer { name "Reviewer" }
-    `)
-    assert.equal(r.issues.length, 0)
-    assert.equal(r.standard.roles.length, 2)
-  })
+    `);
+    assert.equal(r.issues.length, 0);
+    assert.equal(r.standard.roles.length, 2);
+  });
 
   it('flags an error when two roles share an id', () => {
     const r = loadWithIssues(`
       role author { name "First" }
       role author { name "Second" }
-    `)
-    assert.equal(r.issues.length, 1)
-    assert.equal(r.issues[0].code, 'duplicate-id')
-    assert.equal(r.issues[0].construct, 'roles')
-    assert.equal(r.issues[0].id, 'author')
-    assert.ok(r.issues[0].message.includes('author'))
+    `);
+    assert.equal(r.issues.length, 1);
+    assert.equal(r.issues[0].code, 'duplicate-id');
+    assert.equal(r.issues[0].construct, 'roles');
+    assert.equal(r.issues[0].id, 'author');
+    assert.ok(r.issues[0].message.includes('author'));
     // Position should be set and point to second occurrence (line > 1)
-    assert.ok(r.issues[0].position && r.issues[0].position.line > 1)
-  })
+    assert.ok(r.issues[0].position && r.issues[0].position.line > 1);
+  });
 
   it('allows the same ID across DIFFERENT kinds', () => {
     // Cross-kind collisions are NOT duplicates — a Role and a Process
@@ -32,9 +32,9 @@ describe('duplicate-ID detection (parse-time)', () => {
     const r = loadWithIssues(`
       role widget { name "W" }
       process widget { name "W" }
-    `)
-    assert.equal(r.issues.length, 0)
-  })
+    `);
+    assert.equal(r.issues.length, 0);
+  });
 
   it('reports each duplicate occurrence separately', () => {
     // Three roles with id "x" → 2 duplicate issues (2nd and 3rd)
@@ -42,10 +42,10 @@ describe('duplicate-ID detection (parse-time)', () => {
       role x { name "1" }
       role x { name "2" }
       role x { name "3" }
-    `)
-    assert.equal(r.issues.length, 2)
-    assert.ok(r.issues.every(i => i.code === 'duplicate-id'))
-  })
+    `);
+    assert.equal(r.issues.length, 2);
+    assert.ok(r.issues.every(i => i.code === 'duplicate-id'));
+  });
 
   it('detects duplicates across all construct kinds', () => {
     const r = loadWithIssues(`
@@ -53,10 +53,10 @@ describe('duplicate-ID detection (parse-time)', () => {
       process p1 { name "2" }
       form f1 { name "1" }
       form f1 { name "2" }
-    `)
-    assert.equal(r.issues.length, 2)
-    const constructs = new Set(r.issues.map(i => i.construct))
-    assert.ok(constructs.has('processes'))
-    assert.ok(constructs.has('forms'))
-  })
-})
+    `);
+    assert.equal(r.issues.length, 2);
+    const constructs = new Set(r.issues.map(i => i.construct));
+    assert.ok(constructs.has('processes'));
+    assert.ok(constructs.has('forms'));
+  });
+});

--- a/packages/primmel/test/positions.test.ts
+++ b/packages/primmel/test/positions.test.ts
@@ -1,56 +1,56 @@
-import { describe, it } from 'node:test'
-import assert from 'node:assert/strict'
-import { tokenizeWithPositions } from '../src/ser-des/tokenize'
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { tokenizeWithPositions } from '../src/ser-des/tokenize';
 
 describe('tokenizeWithPositions', () => {
   it('returns empty array for empty input', () => {
-    assert.deepEqual(tokenizeWithPositions(''), [])
-  })
+    assert.deepEqual(tokenizeWithPositions(''), []);
+  });
 
   it('records 1-based line and column for each token', () => {
-    const toks = tokenizeWithPositions('hello world')
-    assert.equal(toks[0].value, 'hello')
-    assert.equal(toks[0].start.line, 1)
-    assert.equal(toks[0].start.col, 1)
-    assert.equal(toks[0].start.offset, 0)
-    assert.equal(toks[1].value, 'world')
-    assert.equal(toks[1].start.line, 1)
-    assert.equal(toks[1].start.col, 7)
-    assert.equal(toks[1].start.offset, 6)
-  })
+    const toks = tokenizeWithPositions('hello world');
+    assert.equal(toks[0].value, 'hello');
+    assert.equal(toks[0].start.line, 1);
+    assert.equal(toks[0].start.col, 1);
+    assert.equal(toks[0].start.offset, 0);
+    assert.equal(toks[1].value, 'world');
+    assert.equal(toks[1].start.line, 1);
+    assert.equal(toks[1].start.col, 7);
+    assert.equal(toks[1].start.offset, 6);
+  });
 
   it('increments line counter on newlines', () => {
-    const toks = tokenizeWithPositions('a\nb\nc')
-    assert.equal(toks[1].start.line, 2)
-    assert.equal(toks[2].start.line, 3)
-  })
+    const toks = tokenizeWithPositions('a\nb\nc');
+    assert.equal(toks[1].start.line, 2);
+    assert.equal(toks[2].start.line, 3);
+  });
 
   it('treats quoted strings as single tokens with correct start position', () => {
-    const toks = tokenizeWithPositions('id "hello world"')
-    assert.equal(toks[1].value, '"hello world"')
-    assert.equal(toks[1].start.line, 1)
-    assert.equal(toks[1].start.col, 4)
-    assert.equal(toks[1].start.offset, 3)
-  })
+    const toks = tokenizeWithPositions('id "hello world"');
+    assert.equal(toks[1].value, '"hello world"');
+    assert.equal(toks[1].start.line, 1);
+    assert.equal(toks[1].start.col, 4);
+    assert.equal(toks[1].start.offset, 3);
+  });
 
   it('treats brace blocks as single tokens', () => {
-    const toks = tokenizeWithPositions('id { a b }')
-    assert.equal(toks[1].value, '{ a b }')
-    assert.equal(toks[1].start.col, 4)
-  })
+    const toks = tokenizeWithPositions('id { a b }');
+    assert.equal(toks[1].value, '{ a b }');
+    assert.equal(toks[1].start.col, 4);
+  });
 
   it('skips comments without affecting token positions', () => {
-    const toks = tokenizeWithPositions('// comment\nid value')
-    assert.equal(toks[0].value, 'id')
-    assert.equal(toks[0].start.line, 2)
-    assert.equal(toks[0].start.col, 1)
-    assert.equal(toks[0].start.offset, 11)
-  })
+    const toks = tokenizeWithPositions('// comment\nid value');
+    assert.equal(toks[0].value, 'id');
+    assert.equal(toks[0].start.line, 2);
+    assert.equal(toks[0].start.col, 1);
+    assert.equal(toks[0].start.offset, 11);
+  });
 
   it('records end position immediately after the last char of value', () => {
-    const toks = tokenizeWithPositions('aaa bbb')
-    assert.equal(toks[0].end.line, 1)
-    assert.equal(toks[0].end.col, 4)
-    assert.equal(toks[0].end.offset, 3)
-  })
-})
+    const toks = tokenizeWithPositions('aaa bbb');
+    assert.equal(toks[0].end.line, 1);
+    assert.equal(toks[0].end.col, 4);
+    assert.equal(toks[0].end.offset, 3);
+  });
+});

--- a/packages/primmel/test/term.test.ts
+++ b/packages/primmel/test/term.test.ts
@@ -14,7 +14,10 @@ describe('term keyword', () => {
     assert.equal(s.terms.length, 1);
     assert.equal(s.terms[0].id, 'maximum-capacity');
     assert.equal(s.terms[0].label, 'Maximum capacity');
-    assert.equal(s.terms[0].definition, 'The maximum load that a load cell is designed to measure');
+    assert.equal(
+      s.terms[0].definition,
+      'The maximum load that a load cell is designed to measure',
+    );
     assert.equal(s.terms[0].symbolId, '');
     assert.deepEqual(s.terms[0].referenceIds, []);
   });


### PR DESCRIPTION
CI's `yarn lint` step caught 120 prettier errors (missing semicolons) plus 2 unused imports. Auto-fixed via `yarn lint-fix` and manual cleanup.

Local verifies: lint clean, compile exits 0, all tests pass.