### PR TITLE
refactor: deepen parse/resolve modules via shared helpers and unified types

### DIFF
--- a/packages/primmel/src/duplicate-id.ts
+++ b/packages/primmel/src/duplicate-id.ts
@@ -1,0 +1,55 @@
+// ─────────────────────────────────────────────────────────────────────
+// Duplicate-ID detection helper.
+//
+// Runs at parse time (not post-parse) because the parser silently
+// overwrites duplicate entries in `ctx.<field>`. Without this check,
+// a duplicate ID would just clobber the earlier declaration and the
+// caller would never see the issue. By catching the second occurrence
+// at the moment it's parsed, the issue survives into `ctx.issues`.
+// ─────────────────────────────────────────────────────────────────────
+
+import type { Position } from './ser-des/tokenize';
+import type { ValidationIssue } from './validate';
+import type { ParseContext } from './ser-des/types';
+
+export interface DuplicateIdChecker {
+  /**
+   * Record a declaration. Returns a ValidationIssue if this (field, id)
+   * has been seen before; returns undefined otherwise.
+   */
+  check(
+    field: keyof ParseContext,
+    keyword: string,
+    id: string,
+    position: Position,
+  ): ValidationIssue | undefined;
+}
+
+export function createDuplicateIdChecker(): DuplicateIdChecker {
+  const seen = new Map<keyof ParseContext, Map<string, Position>>();
+
+  return {
+    check(field, keyword, id, position) {
+      let fieldMap = seen.get(field);
+      if (!fieldMap) {
+        fieldMap = new Map();
+        seen.set(field, fieldMap);
+      }
+
+      const prior = fieldMap.get(id);
+      if (prior) {
+        return {
+          severity: 'error',
+          code: 'duplicate-id',
+          construct: String(field),
+          id,
+          message: `Duplicate ${keyword} id "${id}" (first declared at line ${prior.line} col ${prior.col}) — earlier declaration overwritten`,
+          position: { ...position },
+        };
+      }
+
+      fieldMap.set(id, position);
+      return undefined;
+    },
+  };
+}

--- a/packages/primmel/src/ser-des/config/approval.ts
+++ b/packages/primmel/src/ser-des/config/approval.ts
@@ -1,6 +1,7 @@
 import Approval, { ResolvableApproval } from '../../types/Approval';
 import { resolveFromContext } from '../resolve';
-import { escapeString, removePackage, tokenizePackage } from '../tokenize';
+import { escapeString, tokenizePackage } from '../tokenize';
+import { forEachEntry, unwrapped } from '../parse-block';
 import { Dumper, Parser, Resolver } from '../types';
 import type { Registry } from '../../types/data';
 import type Reference from '../../types/Reference';
@@ -23,34 +24,29 @@ export const parseApproval: Parser = function (id, data) {
     },
   };
 
-  if (data !== '') {
-    const t: string[] = tokenizePackage(data);
-    let i = 0;
-    while (i < t.length) {
-      const keyword: string = t[i++];
-      if (i < t.length) {
-        if (keyword === 'modality') {
-          result.modality = t[i++];
-        } else if (keyword === 'name') {
-          result.name = removePackage(t[i++]);
-        } else if (keyword === 'actor') {
-          result._relations.actor = t[i++];
-        } else if (keyword === 'approve_by') {
-          result._relations.approver = t[i++];
-        } else if (keyword === 'approval_record') {
-          result._relations.records = tokenizePackage(t[i++]);
-        } else if (keyword === 'reference') {
-          result._relations.ref = tokenizePackage(t[i++]);
-        } else {
-          i++; // forward-compatible: skip unknown keyword value
-        }
+  forEachEntry(
+    data,
+    (keyword, value) => {
+      if (keyword === 'modality') {
+        result.modality = value();
+      } else if (keyword === 'name') {
+        result.name = unwrapped(value);
+      } else if (keyword === 'actor') {
+        result._relations.actor = value();
+      } else if (keyword === 'approve_by') {
+        result._relations.approver = value();
+      } else if (keyword === 'approval_record') {
+        result._relations.records = tokenizePackage(value());
+      } else if (keyword === 'reference') {
+        result._relations.ref = tokenizePackage(value());
       } else {
-        throw new Error(
-          `Parsing error: approval. ID ${id}: Expecting value for ${keyword}`,
-        );
+        return false;
       }
-    }
-  }
+      return true;
+    },
+    { construct: 'approval', id },
+  );
+
   return ctx => {
     ctx.approvals[id] = result;
     return ctx;
@@ -70,7 +66,7 @@ export const resolveApproval: Resolver<Approval, ResolvableApproval> =
         resolveFromContext<Role>(ctx, 'roles', _relations.approver) ?? null;
     }
     for (const id of _relations.records) {
-      const r = resolveFromContext<Registry>(ctx, 'registers', id);
+      const r = resolveFromContext<Registry>(ctx, 'regs', id);
       if (r !== undefined) {
         p.records.push(r);
       }

--- a/packages/primmel/src/ser-des/config/data.ts
+++ b/packages/primmel/src/ser-des/config/data.ts
@@ -11,12 +11,8 @@ import {
   Variable,
 } from '../../types/data';
 import { resolveFromContext } from '../resolve';
-import {
-  escapeString,
-  removePackage,
-  tokenizeAttributes,
-  tokenizePackage,
-} from '../tokenize';
+import { escapeString, tokenizePackage } from '../tokenize';
+import { forEachEntry, forEachAttribute, unwrapped } from '../parse-block';
 import { Dumper, Parser, Resolver } from '../types';
 
 export const parseEnum: Parser = (id: string, data: string) => {
@@ -24,21 +20,16 @@ export const parseEnum: Parser = (id: string, data: string) => {
     id: id,
     values: [],
   };
-  if (data !== '') {
-    const t: string[] = tokenizePackage(data);
-    let i = 0;
-    while (i < t.length) {
-      const vid: string = t[i++];
-      if (i < t.length) {
-        const vcontent: string = t[i++];
-        result.values.push(parseEnumValue(vid, vcontent));
-      } else {
-        throw new Error(
-          `Parsing error: enum. ID ${id}: Empty definition for value ${vid}`,
-        );
-      }
-    }
-  }
+  // Enum bodies are (value-id, block) pairs, not (keyword, value).
+  // forEachEntry's contract still applies: the visitor always claims.
+  forEachEntry(
+    data,
+    (_vid, value) => {
+      result.values.push(parseEnumValue(_vid, value()));
+      return true;
+    },
+    { construct: 'enum', id },
+  );
 
   return ctx => {
     ctx.enums[id] = result;
@@ -51,24 +42,18 @@ const parseEnumValue = (id: string, data: string) => {
     id: id,
     value: '',
   };
-  if (data !== '') {
-    const t: string[] = tokenizePackage(data);
-    let i = 0;
-    while (i < t.length) {
-      const command: string = t[i++];
-      if (i < t.length) {
-        if (command === 'definition') {
-          ev.value = removePackage(t[i++]);
-        } else {
-          i++; // forward-compatible: skip unknown keyword value
-        }
+  forEachEntry(
+    data,
+    (command, value) => {
+      if (command === 'definition') {
+        ev.value = unwrapped(value);
       } else {
-        throw new Error(
-          `Parsing error: enum value. ID ${id}: Expecting value for ${command}`,
-        );
+        return false;
       }
-    }
-  }
+      return true;
+    },
+    { construct: 'enum value', id },
+  );
   return ev;
 };
 
@@ -82,28 +67,23 @@ export const parseRegistry: Parser = function (id, data) {
     },
   };
 
-  if (data !== '') {
-    const t: string[] = tokenizePackage(data);
-    let i = 0;
-    while (i < t.length) {
-      const command: string = t[i++];
-      if (i < t.length) {
-        if (command === 'title') {
-          result.title = removePackage(t[i++]);
-        } else if (command === 'data_class') {
-          result._relations.data = t[i++];
-        } else {
-          i++; // forward-compatible: skip unknown keyword value
-        }
+  forEachEntry(
+    data,
+    (command, value) => {
+      if (command === 'title') {
+        result.title = unwrapped(value);
+      } else if (command === 'data_class') {
+        result._relations.data = value();
       } else {
-        throw new Error(
-          `Parsing error: registry. ID ${id}: Expecting value for ${command}`,
-        );
+        return false;
       }
-    }
-  }
+      return true;
+    },
+    { construct: 'registry', id },
+  );
+
   return ctx => {
-    ctx.registers[id] = result;
+    ctx.regs[id] = result;
     return ctx;
   };
 };
@@ -114,23 +94,16 @@ export const parseDataClass: Parser = function (id, data) {
     attributes: [],
   };
 
-  if (data !== '') {
-    const t: string[] = tokenizeAttributes(data);
-    let i = 0;
-    while (i < t.length) {
-      const basic: string = t[i++];
-      if (i < t.length) {
-        const details: string = t[i++];
-        result.attributes.push(parseDataAttribute(basic.trim(), details));
-      } else {
-        throw new Error(
-          `Parsing error: class. ID ${id}: Expecting { after ${basic}`,
-        );
-      }
-    }
-  }
+  forEachAttribute(
+    data,
+    (basic, details) => {
+      result.attributes.push(parseDataAttribute(basic.trim(), details));
+    },
+    { construct: 'class', id },
+  );
+
   return ctx => {
-    ctx.dataClasses[id] = result;
+    ctx.dataclasses[id] = result;
     return ctx;
   };
 };
@@ -164,31 +137,24 @@ const parseDataAttribute = (
     basic = basic.substr(0, index);
   }
   result.id = basic.trim();
-  if (details !== '') {
-    const t: string[] = tokenizePackage(details);
-    let i = 0;
-    while (i < t.length) {
-      const keyword: string = t[i++];
-      if (i < t.length) {
-        if (keyword === 'modality') {
-          result.modality = t[i++];
-        } else if (keyword === 'definition') {
-          result.definition = removePackage(t[i++]);
-        } else if (keyword === 'reference') {
-          result._relations.ref = tokenizePackage(t[i++]);
-        } else if (keyword === 'satisfy') {
-          result.satisfy = tokenizePackage(t[i++]);
-        } else {
-          // Forward-compatible: skip unknown keywords (e.g., cardinality, unit, default)
-          i++;
-        }
+  forEachEntry(
+    details,
+    (keyword, value) => {
+      if (keyword === 'modality') {
+        result.modality = value();
+      } else if (keyword === 'definition') {
+        result.definition = unwrapped(value);
+      } else if (keyword === 'reference') {
+        result._relations.ref = tokenizePackage(value());
+      } else if (keyword === 'satisfy') {
+        result.satisfy = tokenizePackage(value());
       } else {
-        throw new Error(
-          `Parsing error: data attribute. ID ${result.id}: Expecting value for ${keyword}`,
-        );
+        return false;
       }
-    }
-  }
+      return true;
+    },
+    { construct: 'data attribute', id: result.id },
+  );
   return result;
 };
 
@@ -214,7 +180,7 @@ export const resolveRegistry: Resolver<Registry, ResolvableRegistry> =
     if (_relations.data !== '') {
       const dc = resolveFromContext<DataClass>(
         ctx,
-        'dataClasses',
+        'dataclasses',
         _relations.data,
       );
       if (dc !== undefined) {
@@ -297,28 +263,22 @@ export const parseVariable: Parser = function (id, data) {
     definition: '',
     description: '',
   };
-  if (data !== '') {
-    const t: string[] = tokenizePackage(data);
-    let i = 0;
-    while (i < t.length) {
-      const keyword: string = t[i++];
-      if (i < t.length) {
-        if (keyword === 'type') {
-          result.type = t[i++];
-        } else if (keyword === 'definition') {
-          result.definition = removePackage(t[i++]);
-        } else if (keyword === 'description') {
-          result.description = removePackage(t[i++]);
-        } else {
-          i++;
-        }
+  forEachEntry(
+    data,
+    (keyword, value) => {
+      if (keyword === 'type') {
+        result.type = value();
+      } else if (keyword === 'definition') {
+        result.definition = unwrapped(value);
+      } else if (keyword === 'description') {
+        result.description = unwrapped(value);
       } else {
-        throw new Error(
-          `Parsing error: variable. ID ${id}: Expecting value for ${keyword}`,
-        );
+        return false;
       }
-    }
-  }
+      return true;
+    },
+    { construct: 'variable', id },
+  );
   return ctx => {
     ctx.variables[id] = result;
     return ctx;

--- a/packages/primmel/src/ser-des/config/gateway.ts
+++ b/packages/primmel/src/ser-des/config/gateway.ts
@@ -1,5 +1,6 @@
 import Gateway, { ExclusiveGateway } from '../../types/Gateway';
-import { escapeString, removePackage, tokenizePackage } from '../tokenize';
+import { escapeString } from '../tokenize';
+import { forEachEntry, unwrapped } from '../parse-block';
 import { Dumper, Parser } from '../types';
 
 export const parseExclusiveGate: Parser = function (id, data) {
@@ -8,24 +9,20 @@ export const parseExclusiveGate: Parser = function (id, data) {
     gatewayType: 'exclusive_gateway',
     label: '',
   };
-  if (data !== '') {
-    const t: Array<string> = tokenizePackage(data);
-    let i = 0;
-    while (i < t.length) {
-      const command: string = t[i++];
-      if (i < t.length) {
-        if (command === 'label') {
-          gateway.label = removePackage(t[i++]);
-        } else {
-          i++; // forward-compatible: skip unknown keyword value
-        }
+
+  forEachEntry(
+    data,
+    (command, value) => {
+      if (command === 'label') {
+        gateway.label = unwrapped(value);
       } else {
-        throw new Error(
-          `Parsing error: Exclusive gateway. ID ${id}: Expecting value for ${command}`,
-        );
+        return false;
       }
-    }
-  }
+      return true;
+    },
+    { construct: 'Exclusive gateway', id },
+  );
+
   return ctx => {
     ctx.gateways[id] = gateway;
     return ctx;

--- a/packages/primmel/src/ser-des/config/index.ts
+++ b/packages/primmel/src/ser-des/config/index.ts
@@ -91,7 +91,7 @@ export const PARSER_CONFIG: ParserConfiguration = {
   class: {
     takesID: true,
     parse: parseDataClass,
-    field: 'dataClasses',
+    field: 'dataclasses',
   },
 
   enum: {
@@ -103,7 +103,7 @@ export const PARSER_CONFIG: ParserConfiguration = {
   data_registry: {
     takesID: true,
     parse: parseRegistry,
-    field: 'registers',
+    field: 'regs',
   },
 
   variable: {
@@ -208,7 +208,19 @@ export const PARSER_CONFIG: ParserConfiguration = {
   },
 };
 
+// Resolver order matters: a resolver may pull items from other ctx tables
+// (via resolveFromContext). Those items get their `_relations` stripped on
+// first read, so a resolver must run AFTER any other resolver whose items
+// it might look up. Concretely: regs reference dataclasses (via
+// `data_class`); processes reference regs/provisions; pages reference
+// processes/approvals/events/gateways. Order: dependencies first, pages last.
 export const RESOLVER_CONFIG: ResolverConfiguration = {
+  dataclasses: {
+    resolve: resolveDataClass,
+  },
+  regs: {
+    resolve: resolveRegistry,
+  },
   provisions: {
     resolve: resolveProvision,
   },
@@ -218,15 +230,6 @@ export const RESOLVER_CONFIG: ResolverConfiguration = {
   approvals: {
     resolve: resolveApproval,
   },
-  pages: {
-    resolve: resolveSubprocess,
-  },
-  dataClasses: {
-    resolve: resolveDataClass,
-  },
-  registers: {
-    resolve: resolveRegistry,
-  },
   notes: {
     resolve: resolveNote,
   },
@@ -235,6 +238,9 @@ export const RESOLVER_CONFIG: ResolverConfiguration = {
   },
   calculations: {
     resolve: resolveCalculation,
+  },
+  pages: {
+    resolve: resolveSubprocess,
   },
 };
 

--- a/packages/primmel/src/ser-des/config/mapProfile.ts
+++ b/packages/primmel/src/ser-des/config/mapProfile.ts
@@ -1,5 +1,5 @@
 import type { Dumper, Parser } from '../types';
-import { removePackage, tokenizePackage } from '../tokenize';
+import { forEachEntry, unwrapped } from '../parse-block';
 import type MapProfile from '../../types/MapProfile';
 
 export const parseMapProfile: Parser = function (namespace, data) {
@@ -9,36 +9,30 @@ export const parseMapProfile: Parser = function (namespace, data) {
     mappings: {},
   };
 
-  if (data !== '') {
-    const t: Array<string> = tokenizePackage(data);
-    let i = 0;
-    while (i < t.length) {
-      const command: string = t[i++];
-      if (i < t.length) {
-        if (command === 'description') {
-          result.description = removePackage(t[i++]);
-        } else if (command === 'mapping') {
-          // mapping block: source → target pairs
-          const block = removePackage(t[i++]);
-          for (const line of block
-            .split(/\n+/)
-            .map(s => s.trim())
-            .filter(s => s)) {
-            const m = line.match(/^(\S+)\s*->\s*(\S+)$/);
-            if (m) {
-              result.mappings[m[1]] = m[2];
-            }
+  forEachEntry(
+    data,
+    (command, value) => {
+      if (command === 'description') {
+        result.description = unwrapped(value);
+      } else if (command === 'mapping') {
+        // mapping block: source → target pairs
+        const block = unwrapped(value);
+        for (const line of block
+          .split(/\n+/)
+          .map(s => s.trim())
+          .filter(s => s)) {
+          const m = line.match(/^(\S+)\s*->\s*(\S+)$/);
+          if (m) {
+            result.mappings[m[1]] = m[2];
           }
-        } else {
-          i++; // forward-compatible: skip unknown keyword value
         }
       } else {
-        throw new Error(
-          `Parsing error: map_profile. NS ${namespace}: Expecting value for ${command}`,
-        );
+        return false;
       }
-    }
-  }
+      return true;
+    },
+    { construct: 'map_profile', id: namespace },
+  );
 
   return ctx => {
     ctx.mapProfiles[namespace] = result;

--- a/packages/primmel/src/ser-des/config/note.ts
+++ b/packages/primmel/src/ser-des/config/note.ts
@@ -1,5 +1,6 @@
 import type { Dumper, Parser, Resolver } from '../types';
-import { escapeString, removePackage, tokenizePackage } from '../tokenize';
+import { escapeString, tokenizePackage } from '../tokenize';
+import { forEachEntry, unwrapped } from '../parse-block';
 import type Note from '../../types/Note';
 import type { NoteType } from '../../types/Note';
 import type { ResolvableNote } from '../../types/Note';
@@ -19,36 +20,30 @@ export const parseNote: Parser = function (id, data) {
     },
   };
 
-  if (data !== '') {
-    const t: Array<string> = tokenizePackage(data);
-    let i = 0;
-    while (i < t.length) {
-      const command: string = t[i++];
-      if (i < t.length) {
-        if (command === 'type') {
-          const v = t[i++] as NoteType;
-          if (!VALID_NOTE_TYPES.includes(v)) {
-            throw new Error(
-              `Parsing error: note. ID ${id}: Unknown type ${v} (valid: ${VALID_NOTE_TYPES.join(
-                ', ',
-              )})`,
-            );
-          }
-          result.type = v;
-        } else if (command === 'message') {
-          result.message = removePackage(t[i++]);
-        } else if (command === 'reference') {
-          result._relations.ref = tokenizePackage(t[i++]);
-        } else {
-          i++; // forward-compatible: skip unknown keyword value
+  forEachEntry(
+    data,
+    (command, value) => {
+      if (command === 'type') {
+        const v = value() as NoteType;
+        if (!VALID_NOTE_TYPES.includes(v)) {
+          throw new Error(
+            `Parsing error: note. ID ${id}: Unknown type ${v} (valid: ${VALID_NOTE_TYPES.join(
+              ', ',
+            )})`,
+          );
         }
+        result.type = v;
+      } else if (command === 'message') {
+        result.message = unwrapped(value);
+      } else if (command === 'reference') {
+        result._relations.ref = tokenizePackage(value());
       } else {
-        throw new Error(
-          `Parsing error: note. ID ${id}: Expecting value for ${command}`,
-        );
+        return false;
       }
-    }
-  }
+      return true;
+    },
+    { construct: 'note', id },
+  );
 
   return ctx => {
     ctx.notes[id] = result;

--- a/packages/primmel/src/ser-des/config/process.ts
+++ b/packages/primmel/src/ser-des/config/process.ts
@@ -1,6 +1,7 @@
 import Process, { ResolvableProcess } from '../../types/process';
 import { resolveFromContext } from '../resolve';
 import { escapeString, removePackage, tokenizePackage } from '../tokenize';
+import { forEachEntry, unwrapped } from '../parse-block';
 import { Dumper, Parser, Resolver } from '../types';
 import type { Registry } from '../../types/data';
 import type Provision from '../../types/Provision';
@@ -27,38 +28,33 @@ export const parseProcess: Parser = function (id, data) {
     },
   };
 
-  if (data !== '') {
-    const t: string[] = tokenizePackage(data);
-    let i = 0;
-    while (i < t.length) {
-      const keyword: string = t[i++];
-      if (i < t.length) {
-        if (keyword === 'modality') {
-          result.modality = t[i++];
-        } else if (keyword === 'name') {
-          result.name = removePackage(t[i++]);
-        } else if (keyword === 'actor') {
-          result._relations.actor = t[i++];
-        } else if (keyword === 'subprocess') {
-          result._relations.page = t[i++];
-        } else if (keyword === 'validate_provision') {
-          result._relations.provision = tokenizePackage(t[i++]);
-        } else if (keyword === 'validate_measurement') {
-          result.measure = tokenizePackage(t[i++]).map(x => removePackage(x));
-        } else if (keyword === 'output') {
-          result._relations.output = tokenizePackage(t[i++]);
-        } else if (keyword === 'reference_data_registry') {
-          result._relations.input = tokenizePackage(t[i++]);
-        } else {
-          i++; // forward-compatible: skip unknown keyword value
-        }
+  forEachEntry(
+    data,
+    (keyword, value) => {
+      if (keyword === 'modality') {
+        result.modality = value();
+      } else if (keyword === 'name') {
+        result.name = unwrapped(value);
+      } else if (keyword === 'actor') {
+        result._relations.actor = value();
+      } else if (keyword === 'subprocess') {
+        result._relations.page = value();
+      } else if (keyword === 'validate_provision') {
+        result._relations.provision = tokenizePackage(value());
+      } else if (keyword === 'validate_measurement') {
+        result.measure = tokenizePackage(value()).map(x => removePackage(x));
+      } else if (keyword === 'output') {
+        result._relations.output = tokenizePackage(value());
+      } else if (keyword === 'reference_data_registry') {
+        result._relations.input = tokenizePackage(value());
       } else {
-        throw new Error(
-          `Parsing error: process. ID ${id}: Expecting value for ${keyword}`,
-        );
+        return false;
       }
-    }
-  }
+      return true;
+    },
+    { construct: 'process', id },
+  );
+
   return ctx => {
     ctx.processes[id] = result;
     return ctx;
@@ -79,13 +75,13 @@ export const resolveProcess: Resolver<Process, ResolvableProcess> = function (
     page: null,
   };
   for (const id of _relations.output) {
-    const r = resolveFromContext<Registry>(ctx, 'registers', id);
+    const r = resolveFromContext<Registry>(ctx, 'regs', id);
     if (r !== undefined) {
       p.output.push(r);
     }
   }
   for (const id of _relations.input) {
-    const r = resolveFromContext<Registry>(ctx, 'registers', id);
+    const r = resolveFromContext<Registry>(ctx, 'regs', id);
     if (r !== undefined) {
       p.input.push(r);
     }

--- a/packages/primmel/src/ser-des/config/provision.ts
+++ b/packages/primmel/src/ser-des/config/provision.ts
@@ -1,6 +1,7 @@
 import type Provision from '../../types/Provision';
 import type { Dumper, Parser, Resolver } from '../types';
-import { escapeString, removePackage, tokenizePackage } from '../tokenize';
+import { escapeString, tokenizePackage } from '../tokenize';
+import { forEachEntry, unwrapped } from '../parse-block';
 import { ResolvableProvision } from '../../types/Provision';
 import type Reference from '../../types/Reference';
 import { resolveFromContext } from '../resolve';
@@ -17,31 +18,25 @@ export const parseProvision: Parser = function (id, data) {
     },
   };
 
-  if (data !== '') {
-    const t: Array<string> = tokenizePackage(data);
-    let i = 0;
-    while (i < t.length) {
-      const command: string = t[i++];
-      if (i < t.length) {
-        if (command === 'modality') {
-          result.modality = t[i++];
-        } else if (command === 'condition') {
-          result.condition = removePackage(t[i++]);
-        } else if (command === 'reference') {
-          result._relations.ref = tokenizePackage(t[i++]);
-        } else {
-          result.subject.set(command, t[i++]);
-        }
+  forEachEntry(
+    data,
+    (command, value) => {
+      if (command === 'modality') {
+        result.modality = value();
+      } else if (command === 'condition') {
+        result.condition = unwrapped(value);
+      } else if (command === 'reference') {
+        result._relations.ref = tokenizePackage(value());
       } else {
-        throw new Error(
-          'Parsing error: provision. ID ' +
-            id +
-            ': Expecting value for ' +
-            command,
-        );
+        // Unknown command becomes a subject key → its raw value.
+        // (Provisions are intentionally extensible: free-form key/value
+        // pairs are part of the spec.)
+        result.subject.set(command, value());
       }
-    }
-  }
+      return true;
+    },
+    { construct: 'provision', id },
+  );
 
   return ctx => {
     ctx.provisions[id] = result;

--- a/packages/primmel/src/ser-des/config/role.ts
+++ b/packages/primmel/src/ser-des/config/role.ts
@@ -1,5 +1,6 @@
 import type { Dumper, Parser } from '../types';
-import { escapeString, removePackage, tokenizePackage } from '../tokenize';
+import { escapeString } from '../tokenize';
+import { forEachEntry, unwrapped } from '../parse-block';
 import Role from '../../types/Role';
 
 export const parseRole: Parser = (id: string, data: string) => {
@@ -7,22 +8,20 @@ export const parseRole: Parser = (id: string, data: string) => {
     id: id,
     name: '',
   };
-  const t: Array<string> = tokenizePackage(data);
-  let i = 0;
-  while (i < t.length) {
-    const keyword: string = t[i++];
-    if (i < t.length) {
+
+  forEachEntry(
+    data,
+    (keyword, value) => {
       if (keyword === 'name') {
-        role.name = removePackage(t[i++]);
+        role.name = unwrapped(value);
       } else {
-        i++; // forward-compatible: skip unknown keyword value
+        return false;
       }
-    } else {
-      throw new Error(
-        `Parsing error: role. ID ${id}: Expecting value for ${keyword}`,
-      );
-    }
-  }
+      return true;
+    },
+    { construct: 'role', id },
+  );
+
   return ctx => {
     ctx.roles[id] = role;
     return ctx;

--- a/packages/primmel/src/ser-des/config/symbol.ts
+++ b/packages/primmel/src/ser-des/config/symbol.ts
@@ -1,5 +1,6 @@
 import type { Dumper, Parser, Resolver } from '../types';
-import { escapeString, removePackage, tokenizePackage } from '../tokenize';
+import { escapeString, tokenizePackage } from '../tokenize';
+import { forEachEntry, unwrapped } from '../parse-block';
 import type Symbol from '../../types/Symbol';
 import type { SymbolType, ResolvableSymbol } from '../../types/Symbol';
 import type Reference from '../../types/Reference';
@@ -28,44 +29,38 @@ export const parseSymbol: Parser = function (id, data) {
     },
   };
 
-  if (data !== '') {
-    const t: Array<string> = tokenizePackage(data);
-    let i = 0;
-    while (i < t.length) {
-      const command: string = t[i++];
-      if (i < t.length) {
-        if (command === 'name') {
-          result.name = removePackage(t[i++]);
-        } else if (command === 'definition') {
-          result.definition = removePackage(t[i++]);
-        } else if (command === 'type') {
-          const v = t[i++] as SymbolType;
-          if (!VALID_SYMBOL_TYPES.includes(v)) {
-            throw new Error(
-              `Parsing error: symbol. ID ${id}: Unknown type ${v} (valid: ${VALID_SYMBOL_TYPES.join(
-                ', ',
-              )})`,
-            );
-          }
-          result.type = v;
-        } else if (command === 'unit') {
-          result.unit = removePackage(t[i++]);
-        } else if (command === 'latex') {
-          result.latex = removePackage(t[i++]);
-        } else if (command === 'values') {
-          result.values = tokenizePackage(t[i++]);
-        } else if (command === 'reference') {
-          result._relations.ref = tokenizePackage(t[i++]);
-        } else {
-          i++; // forward-compatible: skip unknown keyword value
+  forEachEntry(
+    data,
+    (command, value) => {
+      if (command === 'name') {
+        result.name = unwrapped(value);
+      } else if (command === 'definition') {
+        result.definition = unwrapped(value);
+      } else if (command === 'type') {
+        const v = value() as SymbolType;
+        if (!VALID_SYMBOL_TYPES.includes(v)) {
+          throw new Error(
+            `Parsing error: symbol. ID ${id}: Unknown type ${v} (valid: ${VALID_SYMBOL_TYPES.join(
+              ', ',
+            )})`,
+          );
         }
+        result.type = v;
+      } else if (command === 'unit') {
+        result.unit = unwrapped(value);
+      } else if (command === 'latex') {
+        result.latex = unwrapped(value);
+      } else if (command === 'values') {
+        result.values = tokenizePackage(value());
+      } else if (command === 'reference') {
+        result._relations.ref = tokenizePackage(value());
       } else {
-        throw new Error(
-          `Parsing error: symbol. ID ${id}: Expecting value for ${command}`,
-        );
+        return false;
       }
-    }
-  }
+      return true;
+    },
+    { construct: 'symbol', id },
+  );
 
   return ctx => {
     ctx.symbols[id] = result;

--- a/packages/primmel/src/ser-des/config/term.ts
+++ b/packages/primmel/src/ser-des/config/term.ts
@@ -1,5 +1,6 @@
 import type { Dumper, Parser } from '../types';
-import { removePackage, tokenizePackage } from '../tokenize';
+import { tokenizePackage } from '../tokenize';
+import { forEachEntry, unwrapped } from '../parse-block';
 import type Term from '../../types/Term';
 
 export const parseTerm: Parser = function (id, data) {
@@ -12,38 +13,32 @@ export const parseTerm: Parser = function (id, data) {
     ref: [],
   };
 
-  if (data !== '') {
-    const t: Array<string> = tokenizePackage(data);
-    let i = 0;
-    while (i < t.length) {
-      const command: string = t[i++];
-      if (i < t.length) {
-        if (command === 'label') {
-          result.label = removePackage(t[i++]);
-        } else if (command === 'definition') {
-          result.definition = removePackage(t[i++]);
-        } else if (command === 'symbol') {
-          // symbol reference is a bare ID (e.g., `symbol Emax`).
-          // Strip wrapping quotes if present (defensive — most models use bare IDs).
-          const raw = t[i++];
-          result.symbolId =
-            raw.length >= 2 &&
-            raw.charAt(0) === '"' &&
-            raw.charAt(raw.length - 1) === '"'
-              ? raw.slice(1, -1)
-              : raw;
-        } else if (command === 'reference') {
-          result.referenceIds = tokenizePackage(t[i++]);
-        } else {
-          i++; // forward-compatible: skip unknown keyword value
-        }
+  forEachEntry(
+    data,
+    (command, value) => {
+      if (command === 'label') {
+        result.label = unwrapped(value);
+      } else if (command === 'definition') {
+        result.definition = unwrapped(value);
+      } else if (command === 'symbol') {
+        // symbol reference is a bare ID (e.g., `symbol Emax`).
+        // Strip wrapping quotes if present (defensive — most models use bare IDs).
+        const raw = value();
+        result.symbolId =
+          raw.length >= 2 &&
+          raw.charAt(0) === '"' &&
+          raw.charAt(raw.length - 1) === '"'
+            ? raw.slice(1, -1)
+            : raw;
+      } else if (command === 'reference') {
+        result.referenceIds = tokenizePackage(value());
       } else {
-        throw new Error(
-          `Parsing error: term. ID ${id}: Expecting value for ${command}`,
-        );
+        return false;
       }
-    }
-  }
+      return true;
+    },
+    { construct: 'term', id },
+  );
 
   return ctx => {
     ctx.terms[id] = result;

--- a/packages/primmel/src/ser-des/config/viewProfile.ts
+++ b/packages/primmel/src/ser-des/config/viewProfile.ts
@@ -1,5 +1,6 @@
 import type { Dumper, Parser } from '../types';
-import { removePackage, tokenizePackage } from '../tokenize';
+import { tokenizePackage } from '../tokenize';
+import { forEachEntry, unwrapped } from '../parse-block';
 import type ViewProfile from '../../types/ViewProfile';
 
 export const parseViewProfile: Parser = function (id, data) {
@@ -10,28 +11,22 @@ export const parseViewProfile: Parser = function (id, data) {
     visibleElements: [],
   };
 
-  if (data !== '') {
-    const t: Array<string> = tokenizePackage(data);
-    let i = 0;
-    while (i < t.length) {
-      const command: string = t[i++];
-      if (i < t.length) {
-        if (command === 'description') {
-          result.description = removePackage(t[i++]);
-        } else if (command === 'roles') {
-          result.roles = tokenizePackage(t[i++]);
-        } else if (command === 'visible') {
-          result.visibleElements = tokenizePackage(t[i++]);
-        } else {
-          i++; // forward-compatible: skip unknown keyword value
-        }
+  forEachEntry(
+    data,
+    (command, value) => {
+      if (command === 'description') {
+        result.description = unwrapped(value);
+      } else if (command === 'roles') {
+        result.roles = tokenizePackage(value());
+      } else if (command === 'visible') {
+        result.visibleElements = tokenizePackage(value());
       } else {
-        throw new Error(
-          `Parsing error: view_profile. ID ${id}: Expecting value for ${command}`,
-        );
+        return false;
       }
-    }
-  }
+      return true;
+    },
+    { construct: 'view_profile', id },
+  );
 
   return ctx => {
     ctx.viewProfiles[id] = result;

--- a/packages/primmel/src/ser-des/parse-block.ts
+++ b/packages/primmel/src/ser-des/parse-block.ts
@@ -1,0 +1,127 @@
+// ─────────────────────────────────────────────────────────────────────
+// Shared parse-loop helpers.
+//
+// Every keyword-with-block parser follows the same shape:
+//   - tokenize the block
+//   - walk tokens pairwise (keyword, value)
+//   - dispatch on keyword
+//   - throw if a value is missing
+//   - skip unknown keywords for forward compatibility
+//
+// `forEachEntry` concentrates that boilerplate. Each parser supplies a
+// visitor; the visitor claims a keyword by reading its value via the
+// passed `value()` callback. Unclaimed keywords auto-skip their value.
+//
+// `forEachAttribute` handles the slightly different shape used by
+// `class` bodies: a flat sequence of `<name-and-type-spec> { <block> }`
+// pairs, where the name part can include `: type`, `[cardinality]`,
+// etc. The visitor receives the un-tokenized name spec and the brace
+// block as a single string.
+// ─────────────────────────────────────────────────────────────────────
+
+import { tokenizePackage, removePackage } from './tokenize';
+
+export interface ParseEntryErrorContext {
+  /** Construct name for error messages, e.g. "process", "enum value". */
+  construct: string;
+  /** Owning ID for error messages (may be empty for anonymous blocks). */
+  id: string;
+}
+
+/**
+ * Walk the (keyword, value) pairs of a `{ ... }` block, calling the
+ * visitor for each. Returns silently for empty input.
+ *
+ * The visitor receives the keyword and a `value()` reader. Returning
+ * `true` claims the keyword (the visitor called `value()` itself);
+ * returning `false` lets the helper auto-skip the value token, which
+ * is how forward compatibility with newer revisions is preserved.
+ *
+ * Throws on a truncated block (keyword with no value).
+ */
+export function forEachEntry(
+  data: string,
+  visitor: (keyword: string, value: () => string) => boolean,
+  errCtx: ParseEntryErrorContext,
+): void {
+  if (data === '') {
+    return;
+  }
+  const t: string[] = tokenizePackage(data);
+  let i = 0;
+  while (i < t.length) {
+    const keyword = t[i++];
+    if (i >= t.length) {
+      throw new Error(
+        `Parsing error: ${errCtx.construct}. ID ${errCtx.id}: Expecting value for ${keyword}`,
+      );
+    }
+    const claimed = visitor(keyword, () => t[i++]);
+    if (!claimed) {
+      i++; // forward-compat: skip unknown keyword value
+    }
+  }
+}
+
+/**
+ * Walk the `<name-spec> { <block> }` pairs of an attributes-style body,
+ * calling the visitor for each pair. Used by `class` bodies where each
+ * entry has the shape `id[: type][[cardinality]] { details }`.
+ *
+ * Unlike `forEachEntry`, the name spec can span multiple whitespace-
+ * separated tokens (e.g. `attr1: string [0..1]`). Consecutive non-brace
+ * tokens are accumulated into one name spec until the next `{ ... }`
+ * block, which becomes the pair's block.
+ *
+ * The visitor receives the raw name spec (e.g. `"attr1: string [0..1]"`)
+ * and the inner content of the brace block. Empty input is a no-op.
+ *
+ * Throws on a truncated body (name with no block).
+ */
+export function forEachAttribute(
+  data: string,
+  visitor: (nameSpec: string, block: string) => void,
+  errCtx: ParseEntryErrorContext,
+): void {
+  if (data === '') {
+    return;
+  }
+  const t: string[] = tokenizePackage(data);
+  let i = 0;
+  while (i < t.length) {
+    // Accumulate name-spec tokens until we hit the brace block.
+    const nameParts: string[] = [];
+    while (i < t.length && t[i].charAt(0) !== '{') {
+      nameParts.push(t[i++]);
+    }
+    if (nameParts.length === 0) {
+      // Leading brace with no name — malformed.
+      throw new Error(
+        `Parsing error: ${errCtx.construct}. ID ${errCtx.id}: Attribute is missing its name`,
+      );
+    }
+    if (i >= t.length) {
+      throw new Error(
+        `Parsing error: ${errCtx.construct}. ID ${errCtx.id}: Expecting { after ${nameParts.join(' ')}`,
+      );
+    }
+    const blockRaw = t[i++];
+    visitor(nameParts.join(' '), removePackage(blockRaw));
+  }
+}
+
+/**
+ * Convenience: read the next value with surrounding quotes/braces
+ * stripped. Pairs with `forEachEntry` for the common case where a
+ * visitor wants the unwrapped string form.
+ *
+ *     forEachEntry(data, (kw, value) => {
+ *       if (kw === 'name') result.name = unwrapped(value);
+ *       else if (kw === 'modality') result.modality = value();
+ *       else return false;
+ *       return true;
+ *     }, { construct: 'process', id });
+ */
+export function unwrapped(value: () => string): string {
+  return removePackage(value());
+}

--- a/packages/primmel/src/ser-des/parse.ts
+++ b/packages/primmel/src/ser-des/parse.ts
@@ -1,6 +1,6 @@
-import { tokenizeWithPositions, type Token, type Position } from './tokenize';
+import { tokenizeWithPositions, type Token } from './tokenize';
 import { ParseContext, ParserConfiguration } from './types';
-import type { ValidationIssue } from '../validate';
+import { createDuplicateIdChecker } from '../duplicate-id';
 
 export interface ParseOptions {
   /**
@@ -20,8 +20,9 @@ export interface ParseOptions {
  * exact source location of any model problem.
  *
  * Duplicate-ID detection runs during parsing (not post-resolution),
- * because the parser silently overwrites duplicate ctx entries. By
- * catching duplicates here, the issue survives into the result.
+ * because the parser silently overwrites duplicate ctx entries. The
+ * detection itself lives in `duplicate-id.ts` — this module just calls
+ * it at the moment each declaration is parsed.
  */
 export default function parse(
   mmelString: string,
@@ -29,7 +30,7 @@ export default function parse(
   options: ParseOptions = {},
 ): ParseContext {
   const tokens: Token[] = tokenizeWithPositions(mmelString);
-  const seenIds = new Map<keyof ParseContext, Map<string, Position>>();
+  const dupChecker = createDuplicateIdChecker();
 
   // ctx is mutated by parser functions; declared with let because
   // some parsers return a new ctx object via immutable update.
@@ -41,10 +42,10 @@ export default function parse(
     processes: {},
     pages: {},
     gateways: {},
-    registers: {},
+    regs: {},
     references: {},
     provisions: {},
-    dataClasses: {},
+    dataclasses: {},
     events: {},
     enums: {},
     variables: {},
@@ -92,32 +93,18 @@ export default function parse(
       const idTok = tokens[i++];
       const payloadTok = tokens[i++];
 
-      // Duplicate-ID detection: if this keyword config declares a
-      // field, track the ID + position. On second occurrence, emit an
-      // issue but still let the parser overwrite (preserves backward-
-      // compat: callers see the latest declaration).
+      // Duplicate-ID detection runs at parse time because the parser
+      // silently overwrites ctx entries — without this check, the
+      // issue would never surface.
       if (cfg.field) {
-        let fieldMap = seenIds.get(cfg.field);
-        if (!fieldMap) {
-          fieldMap = new Map();
-          seenIds.set(cfg.field, fieldMap);
-        }
-        const prior = fieldMap.get(idTok.value);
-        if (prior) {
-          ctx.issues.push({
-            severity: 'error',
-            code: 'duplicate-id',
-            construct: String(cfg.field),
-            id: idTok.value,
-            message: `Duplicate ${keyword} id "${idTok.value}" (first declared at line ${prior.line} col ${prior.col}) — earlier declaration overwritten`,
-            position: {
-              line: idTok.start.line,
-              col: idTok.start.col,
-              offset: idTok.start.offset,
-            },
-          } as ValidationIssue);
-        } else {
-          fieldMap.set(idTok.value, idTok.start);
+        const issue = dupChecker.check(
+          cfg.field,
+          keyword,
+          idTok.value,
+          idTok.start,
+        );
+        if (issue) {
+          ctx.issues.push(issue);
         }
       }
 

--- a/packages/primmel/src/ser-des/resolve.ts
+++ b/packages/primmel/src/ser-des/resolve.ts
@@ -45,87 +45,76 @@ export function resolveFromContext<T>(
 /**
  * Resolve a ParseContext into a typed Standard.
  *
- * For each registered resolver (RESOLVER_CONFIG), iterate every parsed item
- * of that construct, run the resolver, and append the result to the matching
- * Standard field. Fields without a resolver are passed through directly.
+ * Fields without a resolver are passed through directly (their entries are
+ * already in final form). Fields WITH a resolver are iterated, resolved,
+ * and the result replaces the parsed form on both `ctx` (cached for any
+ * later lookup) and `standard`.
+ *
+ * Adding a new construct with cross-references is now purely a registry
+ * change in RESOLVER_CONFIG — no edit needed here.
  *
  * Lenient: missing references inside a resolver are dropped (not thrown).
  * The partially-resolved item is still returned.
+ *
+ * Resolve order is RESOLVER_CONFIG insertion order; pages must come last
+ * because subprocess components reference processes/approvals/events/
+ * gateways, and those need to be cached in resolved form first.
  */
 export default function resolve(
   ctx: ParseContext,
   resolvers: ResolverConfiguration,
 ): Standard {
-  const standard: Standard = {
+  const standard = {
     meta: ctx.metadata ?? EMPTY_META,
-    roles: Object.values(ctx.roles),
-    provisions: [],
-    pages: [],
-    processes: [],
-    dataclasses: [],
-    regs: [],
-    events: Object.values(ctx.events),
-    gateways: Object.values(ctx.gateways),
-    refs: Object.values(ctx.references),
-    approvals: [],
-    enums: Object.values(ctx.enums),
-    vars: Object.values(ctx.variables),
-    notes: [],
-    tables: Object.values(ctx.tables),
-    figures: Object.values(ctx.figures),
-    links: Object.values(ctx.links),
-    mapProfiles: Object.values(ctx.mapProfiles),
-    viewProfiles: Object.values(ctx.viewProfiles),
-    terms: Object.values(ctx.terms),
-    forms: Object.values(ctx.forms),
-    subforms: Object.values(ctx.subforms),
-    symbols: [],
-    calculations: [],
-    stateMachines: Object.values(ctx.stateMachines),
     root: null,
-  };
+  } as Standard;
 
-  // Resolve order matters: pages reference processes/approvals/events/gateways,
-  // so those must be cached in their resolved form before pages run.
-  resolveField(ctx, resolvers, 'dataClasses', standard.dataclasses);
-  resolveField(ctx, resolvers, 'registers', standard.regs);
-  resolveField(ctx, resolvers, 'provisions', standard.provisions);
-  resolveField(ctx, resolvers, 'processes', standard.processes);
-  resolveField(ctx, resolvers, 'approvals', standard.approvals);
-  resolveField(ctx, resolvers, 'notes', standard.notes);
-  resolveField(ctx, resolvers, 'symbols', standard.symbols);
-  resolveField(ctx, resolvers, 'calculations', standard.calculations);
-  resolveField(ctx, resolvers, 'pages', standard.pages);
+  // Pass-through fields (no resolver — entries are already in final form).
+  // Listed explicitly so the Standard shape drives this, not the resolver
+  // registry. Singletons `meta` and `root` are handled above.
+  standard.roles = Object.values(ctx.roles);
+  standard.events = Object.values(ctx.events);
+  standard.gateways = Object.values(ctx.gateways);
+  standard.refs = Object.values(ctx.references);
+  standard.enums = Object.values(ctx.enums);
+  standard.vars = Object.values(ctx.variables);
+  standard.tables = Object.values(ctx.tables);
+  standard.figures = Object.values(ctx.figures);
+  standard.links = Object.values(ctx.links);
+  standard.mapProfiles = Object.values(ctx.mapProfiles);
+  standard.viewProfiles = Object.values(ctx.viewProfiles);
+  standard.terms = Object.values(ctx.terms);
+  standard.forms = Object.values(ctx.forms);
+  standard.subforms = Object.values(ctx.subforms);
+  standard.stateMachines = Object.values(ctx.stateMachines);
 
-  // Root is a single page reference — look it up after pages are resolved.
+  // Resolved fields — driven entirely by RESOLVER_CONFIG. Order matters:
+  // processes/approvals/etc. must run before pages (subprocess components
+  // reference them via lookupNode).
+  for (const field of Object.keys(resolvers) as Array<keyof ParseContext>) {
+    const cfg = resolvers[field];
+    if (!cfg) {
+      continue;
+    }
+    const table = ctx[field] as Record<string, unknown>;
+    const out: unknown[] = [];
+    for (const [id, item] of Object.entries(table)) {
+      const resolved = cfg.resolve(ctx, item as never) as {
+        _relations?: unknown;
+      };
+      if (resolved === undefined) {
+        continue;
+      }
+      delete resolved._relations;
+      table[id] = resolved;
+      out.push(resolved);
+    }
+    (standard as unknown as Record<string, unknown[]>)[field as string] = out;
+  }
+
   if (ctx.root) {
-    const root = ctx.pages[ctx.root];
-    standard.root = root ?? null;
+    standard.root = ctx.pages[ctx.root] ?? null;
   }
 
   return standard;
-}
-
-function resolveField(
-  ctx: ParseContext,
-  resolvers: ResolverConfiguration,
-  field: keyof ParseContext,
-  out: unknown[],
-) {
-  const cfg = resolvers[field];
-  if (!cfg) {
-    return;
-  }
-  const table = ctx[field] as Record<string, unknown>;
-  for (const [id, item] of Object.entries(table)) {
-    const resolved = cfg.resolve(ctx, item as never) as {
-      _relations?: unknown;
-    };
-    if (resolved === undefined) {
-      continue;
-    }
-    delete resolved._relations;
-    table[id] = resolved;
-    out.push(resolved);
-  }
 }

--- a/packages/primmel/src/ser-des/tokenize.ts
+++ b/packages/primmel/src/ser-des/tokenize.ts
@@ -194,64 +194,6 @@ export function escapeString(x: string): string {
   return x.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 }
 
-export function tokenizeAttributes(x: string): Array<string> {
-  x = removePackage(x);
-  const set: Array<string> = [];
-  let t = '';
-  let i = 0;
-  while (i < x.length) {
-    let char: string = x.charAt(i);
-    if (!isWhiteSpace(char)) {
-      t += char;
-      i++;
-      if (char === '{') {
-        let count = 1;
-        while (i < x.length && count > 0) {
-          char = x.charAt(i);
-          // String-awareness: don't count braces inside quoted strings.
-          if (char === '"') {
-            t += char;
-            i++;
-            while (i < x.length) {
-              const c = x.charAt(i);
-              if (c === '\\' && i + 1 < x.length) {
-                t += c + x.charAt(i + 1);
-                i += 2;
-                continue;
-              }
-              t += c;
-              i++;
-              if (c === '"') {
-                break;
-              }
-            }
-            continue;
-          }
-          if (char === '{') {
-            count++;
-          }
-          if (char === '}') {
-            count--;
-          }
-          t += char;
-          i++;
-        }
-        i++;
-      } else {
-        while (i < x.length && x.charAt(i) !== '{') {
-          t += x.charAt(i);
-          i++;
-        }
-      }
-      set.push(t);
-      t = '';
-    } else {
-      i++;
-    }
-  }
-  return set;
-}
-
 function isWhiteSpace(x: string): boolean {
   return /\s/.test(x);
 }

--- a/packages/primmel/src/ser-des/types.ts
+++ b/packages/primmel/src/ser-des/types.ts
@@ -88,9 +88,9 @@ export interface ParseContext {
   pages: Record<string, ResolvableSubprocess>;
 
   // XXX: Make resolvable
-  registers: Record<string, Registry>;
+  regs: Record<string, Registry>;
   references: Record<string, Reference>;
-  dataClasses: Record<string, DataClass>;
+  dataclasses: Record<string, DataClass>;
   events: Record<string, EventNode>;
   enums: Record<string, Enum>;
   gateways: Record<string, Gateway>;

--- a/packages/primmel/src/validate.ts
+++ b/packages/primmel/src/validate.ts
@@ -14,14 +14,11 @@
 
 import type Standard from './types/Standard';
 import type Form from './types/Form';
+import type { Position } from './ser-des/tokenize';
+
+export type { Position };
 
 export type ValidationSeverity = 'error' | 'warning' | 'info';
-
-export interface Position {
-  line: number;
-  col: number;
-  offset: number;
-}
 
 export interface ValidationIssue {
   severity: ValidationSeverity;

--- a/packages/primmel/test/tokenizer.test.ts
+++ b/packages/primmel/test/tokenizer.test.ts
@@ -3,8 +3,8 @@ import assert from 'node:assert/strict';
 import tokenize, {
   tokenizePackage,
   removePackage,
-  tokenizeAttributes,
 } from '../src/ser-des/tokenize';
+import { forEachAttribute, forEachEntry } from '../src/ser-des/parse-block';
 
 describe('tokenize', () => {
   it('splits whitespace-delimited tokens', () => {
@@ -95,35 +95,78 @@ describe('tokenizePackage', () => {
   });
 });
 
-describe('tokenizeAttributes', () => {
-  // tokenizeAttributes expects a brace-wrapped input (it strips the outer
-  // braces via removePackage, then emits alternating name / block tokens).
-  // Callers like parseDataClass consume the result pairwise.
-  it('emits name and block tokens alternately', () => {
-    const attrs = tokenizeAttributes('{ a { x 1 } b { y 2 } }');
-    assert.equal(attrs.length, 4);
-    assert.equal(attrs[0], 'a ');
-    assert.equal(attrs[1], '{ x 1 }');
-    assert.equal(attrs[2], 'b ');
-    assert.equal(attrs[3], '{ y 2 }');
+describe('forEachAttribute', () => {
+  // forEachAttribute parses class-body style `<name-spec> { <block> }`
+  // pairs. The name-spec may span multiple tokens (e.g. `attr1: string`).
+  const collect = (data: string) => {
+    const out: Array<[string, string]> = [];
+    forEachAttribute(data, (name, block) => out.push([name, block]), {
+      construct: 'test',
+      id: '',
+    });
+    return out;
+  };
+
+  it('emits name-spec and block pairs', () => {
+    assert.deepEqual(collect('{ a { x 1 } b { y 2 } }'), [
+      ['a', ' x 1 '],
+      ['b', ' y 2 '],
+    ]);
   });
 
-  it('counts nested braces as part of one block token', () => {
-    const attrs = tokenizeAttributes('{ id { outer { inner } tail } }');
-    assert.equal(attrs.length, 2);
-    assert.equal(attrs[0], 'id ');
-    assert.equal(attrs[1], '{ outer { inner } tail }');
+  it('keeps multi-token name specs together', () => {
+    assert.deepEqual(collect('{ a: string { x 1 } b: int [0..1] { y 2 } }'), [
+      ['a: string', ' x 1 '],
+      ['b: int [0..1]', ' y 2 '],
+    ]);
+  });
+
+  it('counts nested braces as part of one block', () => {
+    assert.deepEqual(collect('{ id { outer { inner } tail } }'), [
+      ['id', ' outer { inner } tail '],
+    ]);
   });
 
   it('does NOT count braces inside quoted strings', () => {
-    const attrs = tokenizeAttributes('{ id { default "has } char" } }');
-    assert.equal(attrs.length, 2);
-    assert.equal(attrs[1], '{ default "has } char" }');
+    assert.deepEqual(collect('{ id { default "has } char" } }'), [
+      ['id', ' default "has } char" '],
+    ]);
   });
 
   it('does NOT terminate strings on escaped quotes', () => {
-    const attrs = tokenizeAttributes('{ id { default "val \\" tail" } }');
-    assert.equal(attrs.length, 2);
-    assert.equal(attrs[1], '{ default "val \\" tail" }');
+    assert.deepEqual(collect('{ id { default "val \\" tail" } }'), [
+      ['id', ' default "val \\" tail" '],
+    ]);
+  });
+
+  it('throws on a truncated body', () => {
+    assert.throws(() => collect('{ a b c }'), /Expecting \{ after a b c/);
+  });
+});
+
+describe('forEachEntry', () => {
+  it('auto-skips unknown keywords for forward compat', () => {
+    const seen: Array<[string, string | undefined]> = [];
+    forEachEntry(
+      '{ known value1 unknown value2 }',
+      (kw, value) => {
+        if (kw === 'known') {
+          seen.push([kw, value()]);
+          return true;
+        }
+        return false;
+      },
+      { construct: 'test', id: '' },
+    );
+    // 'unknown' should be auto-skipped; 'known' is claimed.
+    assert.deepEqual(seen, [['known', 'value1']]);
+  });
+
+  it('throws on truncated block', () => {
+    assert.throws(
+      () =>
+        forEachEntry('{ orphan }', () => true, { construct: 'test', id: 'x' }),
+      /Expecting value for orpha/,
+    );
   });
 });


### PR DESCRIPTION
## Summary

Architecture review follow-up. Five changes that deepen modules by concentrating behaviour behind smaller interfaces. Each addresses a specific friction point surfaced by the deletion test.

### 1. Unified `Position` type
Was duplicated identically in `tokenize.ts:11` and `validate.ts:20`. Now single source: `ser-des/tokenize.ts` owns it; `validate.ts` re-exports.

### 2. `ParseContext` field names aligned with `Standard`
Was: `dataClasses`/`registers` (ParseContext) vs `dataclasses`/`regs` (Standard). `resolve.ts` carried the mapping as coordination tax. Renamed ParseContext fields to match, then collapsed the bespoke `resolveField(...)` calls into a single loop over `RESOLVER_CONFIG`. **Adding a construct with cross-references is now purely a registry change — no edit to `resolve()` needed.**

### 3. Extracted duplicate-ID checker (`src/duplicate-id.ts`)
`parse.ts` was doing three jobs (tokenize dispatch, position tracking, duplicate-ID detection). Detection now lives in `createDuplicateIdChecker()`. `parse.ts` is back to one concern; the checker returns an issue or undefined.

### 4. Shared parse-loop helpers (`src/ser-des/parse-block.ts`)
13 parsers each duplicated ~15 lines of "tokenize → walk pairs → guard → throw → skip unknown". Two helpers concentrate the boilerplate:
- `forEachEntry(data, visitor, errCtx)` — for keyword/value blocks
- `forEachAttribute(data, visitor, errCtx)` — for class-body `<name-spec> { block }` pairs

Visitors claim a keyword by reading its value; unclaimed keywords auto-skip. This also let us delete the duplicated `tokenizeAttributes` scanner (~55 lines) — its job is now done by `forEachAttribute` + the main tokenizer.

### 5. `RESOLVER_CONFIG` reordered in dependency order
The generic resolve() loop iterates RESOLVER_CONFIG insertion order. Reordered so `dataclasses`/`regs` run before `processes` (which look them up via `resolveFromContext`, which strips `_relations` on first read). Comment in `config/index.ts` documents the constraint.

## Test plan

- [x] `tsc --noEmit` — 0 errors
- [x] `yarn lint` — 0 errors, 0 warnings (was 4 warnings on `any` types — now 0)
- [x] `yarn test` — **98/98 pass** (was 94; +4 new specs for `forEachEntry`/`forEachAttribute`)
- [x] `yarn build` — emits cleanly to `dist/`

## Net change

- 20 files changed, 636 insertions / 573 deletions
- 2 new modules: `src/duplicate-id.ts`, `src/ser-des/parse-block.ts`
- 1 module deleted: `tokenizeAttributes` function (~55 lines removed from `tokenize.ts`)
