### PR TITLE
Fix resolver crash on multi-subprocess models

### DIFF
--- a/packages/primmel/src/ser-des/config/flow.ts
+++ b/packages/primmel/src/ser-des/config/flow.ts
@@ -212,9 +212,11 @@ function readEdge(id: string, data: string): ResolvableEdge {
  */
 export const resolveSubprocess: Resolver<Subprocess, ResolvableSubprocess> =
   function (ctx, unresolved) {
+    const relations = unresolved._relations ?? { childs: [], edges: [], data: [] };
+    const components = unresolved._components ?? {};
     const componentsById = new Map<string, ResolvableSubprocessComponent>();
-    for (const c of Object.values(unresolved._components)) {
-      componentsById.set(c._relations.element, c);
+    for (const c of Object.values(components)) {
+      if (c._relations?.element) componentsById.set(c._relations.element, c);
     }
 
     const resolveComponent = (
@@ -244,9 +246,9 @@ export const resolveSubprocess: Resolver<Subprocess, ResolvableSubprocess> =
 
     return {
       id: unresolved.id,
-      childs: unresolved._relations.childs.map(resolveComponent),
-      edges: unresolved._relations.edges.map(resolveEdge),
-      data: unresolved._relations.data.map(resolveComponent),
+      childs: relations.childs.map(resolveComponent),
+      edges: relations.edges.map(resolveEdge),
+      data: relations.data.map(resolveComponent),
     };
   };
 

--- a/packages/primmel/src/ser-des/resolve.ts
+++ b/packages/primmel/src/ser-des/resolve.ts
@@ -17,6 +17,12 @@ const EMPTY_META: Metadata = {
  * Returns the item (with `_relations` stripped if it had any) or `undefined`
  * if the ID is not present. Lenient by design — callers decide whether an
  * undefined miss is an error.
+ *
+ * Pure: does NOT mutate `ctx`. The caller receives a fresh object when
+ * `_relations` needs stripping; the original entry stays intact for its
+ * own resolver. Caching the stripped form back into the table caused
+ * ordering bugs: a resolver for X reading an item from Y via this
+ * function would strip Y's `_relations` before Y's own resolver ran.
  */
 export function resolveFromContext<T>(
   ctx: ParseContext,
@@ -36,7 +42,6 @@ export function resolveFromContext<T>(
   if (anyItem._relations) {
     const stripped = { ...item };
     delete (stripped as unknown as { _relations?: unknown })._relations;
-    table[id] = stripped;
     return stripped;
   }
   return item;
@@ -47,8 +52,7 @@ export function resolveFromContext<T>(
  *
  * Fields without a resolver are passed through directly (their entries are
  * already in final form). Fields WITH a resolver are iterated, resolved,
- * and the result replaces the parsed form on both `ctx` (cached for any
- * later lookup) and `standard`.
+ * and the result is appended to the matching Standard field.
  *
  * Adding a new construct with cross-references is now purely a registry
  * change in RESOLVER_CONFIG — no edit needed here.
@@ -56,9 +60,9 @@ export function resolveFromContext<T>(
  * Lenient: missing references inside a resolver are dropped (not thrown).
  * The partially-resolved item is still returned.
  *
- * Resolve order is RESOLVER_CONFIG insertion order; pages must come last
- * because subprocess components reference processes/approvals/events/
- * gateways, and those need to be cached in resolved form first.
+ * Order-independent: resolveFromContext is pure (does not mutate ctx),
+ * so resolvers may read from any ctx table at any time without observing
+ * partial state from other resolvers.
  */
 export default function resolve(
   ctx: ParseContext,
@@ -70,8 +74,6 @@ export default function resolve(
   } as Standard;
 
   // Pass-through fields (no resolver — entries are already in final form).
-  // Listed explicitly so the Standard shape drives this, not the resolver
-  // registry. Singletons `meta` and `root` are handled above.
   standard.roles = Object.values(ctx.roles);
   standard.events = Object.values(ctx.events);
   standard.gateways = Object.values(ctx.gateways);
@@ -88,17 +90,20 @@ export default function resolve(
   standard.subforms = Object.values(ctx.subforms);
   standard.stateMachines = Object.values(ctx.stateMachines);
 
-  // Resolved fields — driven entirely by RESOLVER_CONFIG. Order matters:
-  // processes/approvals/etc. must run before pages (subprocess components
-  // reference them via lookupNode).
+  // Resolved fields — driven entirely by RESOLVER_CONFIG. The loop is
+  // order-independent: resolveFromContext is pure, so resolvers may read
+  // from any ctx table at any time without observing partial state.
   for (const field of Object.keys(resolvers) as Array<keyof ParseContext>) {
     const cfg = resolvers[field];
     if (!cfg) {
       continue;
     }
-    const table = ctx[field] as Record<string, unknown>;
+    const table = ctx[field] as Record<string, unknown> | undefined;
+    if (!table) {
+      continue;
+    }
     const out: unknown[] = [];
-    for (const [id, item] of Object.entries(table)) {
+    for (const [, item] of Object.entries(table)) {
       const resolved = cfg.resolve(ctx, item as never) as {
         _relations?: unknown;
       };
@@ -106,7 +111,6 @@ export default function resolve(
         continue;
       }
       delete resolved._relations;
-      table[id] = resolved;
       out.push(resolved);
     }
     (standard as unknown as Record<string, unknown[]>)[field as string] = out;

--- a/packages/primmel/test/subprocess.test.ts
+++ b/packages/primmel/test/subprocess.test.ts
@@ -141,4 +141,55 @@ describe('subprocess resolution', () => {
     assert.match(dumped, /y 4/);
     assert.match(dumped, /data \{[\s\S]*d1 \{/);
   });
+
+  it('resolves multiple subprocesses without crashing (regression)', () => {
+    // Previously crashed with "Cannot read properties of undefined
+    // (reading 'childs')" when resolveFromContext cached stripped pages
+    // back into ctx, stripping _relations before the pages resolver ran.
+    const src = `
+      role Warehouse { name "Warehouse" }
+      start_event Start1 { }
+      end_event End1 { }
+      process DoA {
+        name "Do A"
+        actor Warehouse
+        subprocess FlowA
+      }
+      process DoB {
+        name "Do B"
+        actor Warehouse
+        subprocess FlowB
+      }
+      subprocess FlowA {
+        elements {
+          Start1 { x 0 y 0 }
+          DoA { x 0 y 100 }
+          End1 { x 0 y 200 }
+        }
+        process_flow {
+          e1 { from Start1 to DoA }
+          e2 { from DoA to End1 }
+        }
+        data { }
+      }
+      subprocess FlowB {
+        elements {
+          Start1 { x 0 y 0 }
+          DoB { x 0 y 100 }
+        }
+        process_flow {
+          e1 { from Start1 to DoB }
+        }
+        data { }
+      }
+    `;
+    const s = load(src);
+    assert.equal(s.pages.length, 2);
+    const flowA = s.pages.find(p => p.id === 'FlowA');
+    const flowB = s.pages.find(p => p.id === 'FlowB');
+    assert.equal(flowA?.childs.length, 3);
+    assert.equal(flowA?.edges.length, 2);
+    assert.equal(flowB?.childs.length, 2);
+    assert.equal(flowB?.edges.length, 1);
+  });
 });


### PR DESCRIPTION
## Root cause

`resolveFromContext` cached stripped items back into `ctx`. When the process resolver read a page via `resolveFromContext`, it stripped `_relations` from the page. When the pages resolver ran later, the page had no `_relations` and `resolveSubprocess` crashed.

## Fix

- `resolveFromContext`: removed `table[id] = stripped` caching — original stays intact for its own resolver
- resolve loop: removed `table[id] = resolved` caching — items not mutated during resolution
- Added guard for undefined tables
- Added null-guards in `resolveSubprocess` for `_relations` and `_components`

## Test

99 tests pass (98 + 1 new regression test for multi-subprocess models).