### PR TITLE
Eliminate resolve.ts pass-through hardcoded list

### DIFF
--- a/packages/primmel/src/ser-des/config/index.ts
+++ b/packages/primmel/src/ser-des/config/index.ts
@@ -332,10 +332,13 @@ function buildResolverConfig(
 ): ResolverConfiguration {
   const out: ResolverConfiguration = {};
   for (const c of constructs) {
-    if (!c.field || !c.resolve) {
+    if (!c.field) {
       continue;
     }
-    out[c.field] = { resolve: c.resolve };
+    out[c.field] = {
+      resolve: c.resolve ??
+        (((_ctx: unknown, item: unknown) => item) as never),
+    };
   }
   return out;
 }

--- a/packages/primmel/src/ser-des/resolve.ts
+++ b/packages/primmel/src/ser-des/resolve.ts
@@ -73,26 +73,10 @@ export default function resolve(
     root: null,
   } as Standard;
 
-  // Pass-through fields (no resolver — entries are already in final form).
-  standard.roles = Object.values(ctx.roles);
-  standard.events = Object.values(ctx.events);
-  standard.gateways = Object.values(ctx.gateways);
-  standard.references = Object.values(ctx.references);
-  standard.enums = Object.values(ctx.enums);
-  standard.variables = Object.values(ctx.variables);
-  standard.tables = Object.values(ctx.tables);
-  standard.figures = Object.values(ctx.figures);
-  standard.links = Object.values(ctx.links);
-  standard.mapProfiles = Object.values(ctx.mapProfiles);
-  standard.viewProfiles = Object.values(ctx.viewProfiles);
-  standard.terms = Object.values(ctx.terms);
-  standard.forms = Object.values(ctx.forms);
-  standard.subforms = Object.values(ctx.subforms);
-  standard.stateMachines = Object.values(ctx.stateMachines);
-
-  // Resolved fields — driven entirely by RESOLVER_CONFIG. The loop is
-  // order-independent: resolveFromContext is pure, so resolvers may read
-  // from any ctx table at any time without observing partial state.
+  // All constructs go through the resolver loop. Pass-through constructs
+  // (no cross-references) have auto-generated identity resolvers from
+  // buildResolverConfig — no hardcoded field list here. Adding a new
+  // pass-through construct is purely a config change.
   for (const field of Object.keys(resolvers) as Array<keyof ParseContext>) {
     const cfg = resolvers[field];
     if (!cfg) {


### PR DESCRIPTION
## Summary

The resolve function had 15 hardcoded pass-through lines for constructs without resolvers. Adding a new pass-through construct required editing resolve.ts — an OCP violation.

## Fix

`buildResolverConfig` now auto-generates identity resolvers for constructs that have a field but no resolve function. All constructs go through the same resolver loop. The 15-line pass-through section is deleted.

Adding a new pass-through construct is now purely a config change — one `defineConstruct` entry with no `resolve` property.

## Verification

- 107 tests pass (0 fail)
- TypeScript compiles clean
- Multi-subprocess model (03-process-flow.prl) resolves correctly: 2 pages, 3 roles, 6 events, 2 gateways