### PR TITLE
Release 1.2.1

### DIFF
--- a/packages/primmel/package.json
+++ b/packages/primmel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primmel/primmel",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Primmel — parser, types, and serializer for the Primmel modelling language (successor to MMEL)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Patch release. Bug fixes and refactors since 1.2.0:

- **Fix**: `state_machine` dumper now escapes `guard`/`where`/`set` values via `escapeString` — round-trip was broken if any contained `"` or `\`. Same fix applied to `term.ts` label/definition.
- **Fix**: `includes.ts` no longer expands `include "..."` directives inside `#` or `//` comments. The two stages (preprocessor + tokenizer) now agree on what counts as content.
- **Fix**: Resolver crash on multi-subprocess models (defensive null-guarding in `resolveSubprocess`).
- **Refactor**: `defineConstruct()` factory collapses the 3-registry split (PARSER/RESOLVER/DUMPER) into one declaration per construct.
- **Refactor**: `resolveFromContext` is now pure — does not mutate `ctx`. Resolver order is no longer load-bearing.
- **Refactor**: `removePackage` → `unwrapBlock` rename (the old name suggested brace-awareness and led to bare-ID mangling bugs).
- **Refactor**: `validate.ts` Validator class → standalone functions + `VALIDATORS` registry. `checkEmptyIds` now iterates generically.
- **Refactor**: `flow.ts` sub-parsers no longer misuse `Parser<C>` type parameter — proper `SubprocessSubParser` type.
- **Tests**: 122 specs (was 99). New coverage: validate.ts (15 specs), resolver unit tests (8 specs), parser-loop helpers.

## Test plan

- [x] `tsc --noEmit` — 0 errors
- [x] `yarn lint` — 0 errors, 0 warnings
- [x] `yarn test` — 122/122 pass
- [ ] After merge: create GitHub Release tagged `v1.2.1` → release.yml publishes to npm with provenance
