### PR TITLE
Fix browser build: include dist-browser in npm package (1.3.1)

### DIFF
--- a/packages/primmel/package.json
+++ b/packages/primmel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primmel/primmel",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Primmel — parser, types, and serializer for the Primmel modelling language (successor to MMEL)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -18,7 +18,7 @@
   ],
   "exports": {
     ".": {
-      "browser": "./dist-browser/index.js",
+      "browser": "./dist-browser/index.mjs",
       "import": "./dist/index.js",
       "require": "./dist/index.js",
       "types": "./dist/index.d.ts"
@@ -26,12 +26,13 @@
   },
   "scripts": {
     "build": "../../node_modules/.bin/tsc",
-    "build:browser": "vite build --config ../../vite.browser.config.ts",
-    "prepublishOnly": "yarn build",
+    "build:browser": "../../node_modules/.bin/vite build --config ../../vite.browser.config.ts",
+    "prepublishOnly": "yarn build && yarn build:browser",
     "test": "node --test --import tsx test/*.test.ts"
   },
   "files": [
     "dist/",
+    "dist-browser/",
     "README.adoc",
     "LICENSE"
   ],

--- a/vite.browser.config.ts
+++ b/vite.browser.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
       formats: ['es'],
       fileName: 'index',
     },
-    outDir: 'packages/primmel/dist-browser',
+    outDir: resolve(__dirname, 'packages/primmel/dist-browser'),
     emptyOutDir: true,
     rollupOptions: {
       external: [],


### PR DESCRIPTION
## Summary

Three bugs prevented the browser bundle from working in the published npm package:

1. **Wrong export extension**: `exports.browser` pointed to `dist-browser/index.js` but Vite produces `dist-browser/index.mjs`
2. **Missing from files**: The `files` array only included `dist/`, so `dist-browser/` was never published
3. **Not built at publish time**: `prepublishOnly` only ran `tsc`, not the browser build

Also fixed `vite.browser.config.ts`: the `outDir` was a relative string resolved against the workspace CWD, producing a double-nested path (`packages/primmel/packages/primmel/dist-browser/`). Changed to `resolve(__dirname, ...)`.

## Verification

- `yarn install --immutable` — clean
- `yarn compile` — 0 errors
- `yarn lint` — 0 errors
- `yarn test` — 122 pass, 0 fail
- `yarn build` — clean
- `yarn workspace @primmel/primmel run build:browser` — produces `packages/primmel/dist-browser/index.mjs` (51.70 kB, 10.94 kB gzipped)

## After merge

Tag `v1.3.1` and create a GitHub Release to trigger trusted publishing.
