### PR TITLE
Implement nested processes (processes within processes)

### DIFF
--- a/packages/primmel/src/ser-des/config/process.ts
+++ b/packages/primmel/src/ser-des/config/process.ts
@@ -3,6 +3,7 @@ import { resolveFromContext } from '../resolve';
 import { escapeString, unwrapBlock, tokenizePackage } from '../tokenize';
 import { forEachEntry, unwrapped } from '../parse-block';
 import { Dumper, Parser, Resolver } from '../types';
+import type { ParseContext } from '../types';
 import type { Registry } from '../../types/data';
 import type Provision from '../../types/Provision';
 import type Role from '../../types/Role';
@@ -20,6 +21,7 @@ export const parseProcess: Parser = function (id, data) {
     page: null,
     measure: [],
     parent: '',
+    children: [],
     _relations: {
       actor: '',
       output: [],
@@ -28,6 +30,39 @@ export const parseProcess: Parser = function (id, data) {
       page: '',
     },
   };
+
+  const childModifiers: ((ctx: ParseContext) => ParseContext)[] = [];
+
+  if (data.trim() !== '') {
+    const tokens = tokenizePackage(data);
+    const filtered: string[] = [];
+    let i = 0;
+    while (i < tokens.length) {
+      if (
+        tokens[i] === 'process' &&
+        i + 2 < tokens.length &&
+        tokens[i + 2].startsWith('{')
+      ) {
+        const childId = tokens[i + 1];
+        const childBlock = tokens[i + 2];
+        const childModifier = parseProcess(childId, childBlock);
+        childModifiers.push((ctx: ParseContext) => {
+          ctx = childModifier(ctx);
+          const childProc = ctx.processes[childId];
+          if (childProc) {
+            childProc.parent = id;
+          }
+          return ctx;
+        });
+        result.children.push(childId);
+        i += 3;
+      } else {
+        filtered.push(tokens[i]);
+        i++;
+      }
+    }
+    data = '{ ' + filtered.join(' ') + ' }';
+  }
 
   forEachEntry(
     data,
@@ -60,6 +95,9 @@ export const parseProcess: Parser = function (id, data) {
 
   return ctx => {
     ctx.processes[id] = result;
+    for (const mod of childModifiers) {
+      ctx = mod(ctx);
+    }
     return ctx;
   };
 };
@@ -105,6 +143,33 @@ export const resolveProcess: Resolver<Process, ResolvableProcess> = function (
   return p;
 };
 
+function indentBlock(block: string): string {
+  return block
+    .split('\n')
+    .map(line => (line ? '  ' + line : line))
+    .join('\n');
+}
+
+export function dumpProcessTree(
+  process: Process,
+  lookup: Map<string, Process>,
+): string {
+  let out = dumpProcess(process);
+  if (process.children.length > 0) {
+    const childBlocks: string[] = [];
+    for (const childId of process.children) {
+      const child = lookup.get(childId);
+      if (child) {
+        childBlocks.push(indentBlock(dumpProcessTree(child, lookup)));
+      }
+    }
+    if (childBlocks.length > 0) {
+      out = out.replace(/\n}\n$/, '\n' + childBlocks.join('\n') + '}\n');
+    }
+  }
+  return out;
+}
+
 export const dumpProcess: Dumper<Process> = function (process) {
   let out: string = 'process ' + process.id + ' {\n';
   out += '  name "' + escapeString(process.name) + '"\n';
@@ -145,7 +210,7 @@ export const dumpProcess: Dumper<Process> = function (process) {
   if (process.page !== null) {
     out += '  canvas ' + process.page.id + '\n';
   }
-  if (process.parent) {
+  if (process.parent && process.children.length === 0) {
     out += '  parent ' + process.parent + '\n';
   }
   out += '}\n';

--- a/packages/primmel/src/ser-des/dump.ts
+++ b/packages/primmel/src/ser-des/dump.ts
@@ -1,14 +1,19 @@
 import Standard from '../types/Standard';
 import { dumpMetadata } from './config/metadata';
+import { dumpProcessTree } from './config/process';
 import { DumperConfiguration } from './types';
 
 /**
- * Serialize a Standard back to a .mmel string.
+ * Serialize a Standard back to a .prl string.
  *
  * `root` and `meta` are emitted first because they are singletons (not
  * arrays on Standard) and conventionally appear at the top of the file.
  * Every other field is dumped by iterating its array and calling the
  * registered per-item Dumper on each element.
+ *
+ * Processes are special-cased: nested child processes (those with a
+ * non-empty `parent` that also appear in another process's `children`)
+ * are emitted inside their parent's block, not at the top level.
  */
 export default function dump(
   model: Standard,
@@ -22,7 +27,23 @@ export default function dump(
 
   out += dumpMetadata(model.meta) + '\n';
 
+  const childIds = new Set<string>();
+  for (const p of model.processes) {
+    for (const c of p.children) {
+      childIds.add(c);
+    }
+  }
+  const processMap = new Map(model.processes.map(p => [p.id, p]));
+
   (Object.keys(dumpers) as Array<keyof DumperConfiguration>).forEach(field => {
+    if (field === 'processes') {
+      for (const p of model.processes) {
+        if (!childIds.has(p.id)) {
+          out += dumpProcessTree(p, processMap);
+        }
+      }
+      return;
+    }
     const items = model[field] as unknown[];
     const dumper = dumpers[field] as (item: unknown) => string;
     for (const item of items) {

--- a/packages/primmel/src/types/process.ts
+++ b/packages/primmel/src/types/process.ts
@@ -15,6 +15,7 @@ export default interface Process {
   page: Subprocess | null;
   measure: string[];
   parent: string;
+  children: string[];
 }
 
 export type ResolvableProcess = Resolvable<

--- a/packages/primmel/test/nested-processes.test.ts
+++ b/packages/primmel/test/nested-processes.test.ts
@@ -1,0 +1,160 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { load, dump } from '../src/ser-des/index.js';
+
+describe('Nested processes', () => {
+  it('parses a process with nested child processes', () => {
+    const model = load(`root Root
+
+version "v1.0.0"
+
+metadata {
+  title "Test"
+  schema "Primmel 0.1"
+}
+
+start_event Start { }
+end_event Done { }
+
+process Manufacturing {
+  name "Manufacture product"
+
+  process Assembly {
+    name "Assemble components"
+  }
+
+  process QualityControl {
+    name "Inspect quality"
+  }
+}
+
+canvas Root {
+  elements {
+    Start { x 0 y 0 }
+    Done  { x 0 y 100 }
+  }
+  process_flow {
+    E1 { from Start to Done }
+  }
+}`);
+
+    const parent = model.processes.find(p => p.id === 'Manufacturing');
+    assert.ok(parent, 'Manufacturing process should exist');
+    assert.equal(parent.name, 'Manufacture product');
+    assert.equal(parent.children.length, 2);
+    assert.ok(parent.children.includes('Assembly'));
+    assert.ok(parent.children.includes('QualityControl'));
+
+    const assembly = model.processes.find(p => p.id === 'Assembly');
+    assert.ok(assembly, 'Assembly child process should exist');
+    assert.equal(assembly.name, 'Assemble components');
+    assert.equal(assembly.parent, 'Manufacturing');
+
+    const qc = model.processes.find(p => p.id === 'QualityControl');
+    assert.ok(qc, 'QualityControl child process should exist');
+    assert.equal(qc.name, 'Inspect quality');
+    assert.equal(qc.parent, 'Manufacturing');
+  });
+
+  it('round-trips nested processes through dump', () => {
+    const original = `root Root
+
+version "v1.0.0"
+
+metadata {
+  title "Test"
+  schema "Primmel 0.1"
+}
+
+start_event Start { }
+end_event Done { }
+
+process Manufacturing {
+  name "Manufacture product"
+
+  process Assembly {
+    name "Assemble components"
+  }
+}
+
+canvas Root {
+  elements {
+    Start { x 0 y 0 }
+    Done  { x 0 y 100 }
+  }
+  process_flow {
+    E1 { from Start to Done }
+  }
+}`;
+
+    const model = load(original);
+    const dumped = dump(model);
+
+    assert.ok(
+      dumped.includes('process Manufacturing {'),
+      'parent process in output',
+    );
+    assert.ok(dumped.includes('process Assembly {'), 'child process in output');
+    assert.ok(
+      dumped.includes('name "Assemble components"'),
+      'child name preserved',
+    );
+
+    const posParent = dumped.indexOf('process Manufacturing {');
+    const posChild = dumped.indexOf('process Assembly {');
+    assert.ok(posChild > posParent, 'child should appear after parent opening');
+
+    const posParentClose = dumped.indexOf('}', posChild);
+    assert.ok(posParentClose > posChild, 'parent close should be after child');
+
+    const reloaded = load(dumped);
+    const mfg = reloaded.processes.find(p => p.id === 'Manufacturing');
+    assert.ok(mfg, 'parent survives round-trip');
+    assert.equal(mfg.children.length, 1);
+    assert.equal(mfg.children[0], 'Assembly');
+  });
+
+  it('preserves other process fields when nesting', () => {
+    const model = load(`root Root
+
+version "v1.0.0"
+
+metadata {
+  title "Test"
+  schema "Primmel 0.1"
+}
+
+role Factory { name "Factory" }
+
+start_event Start { }
+end_event Done { }
+
+process Manufacturing {
+  name "Manufacture"
+  actor Factory
+
+  process Assembly {
+    name "Assembly"
+  }
+}
+
+canvas Root {
+  elements {
+    Start { x 0 y 0 }
+    Done  { x 0 y 100 }
+  }
+  process_flow {
+    E1 { from Start to Done }
+  }
+}`);
+
+    const parent = model.processes.find(p => p.id === 'Manufacturing');
+    assert.ok(parent?.actor, 'parent actor preserved');
+    assert.equal(parent.actor!.id, 'Factory');
+    assert.equal(parent.children.length, 1);
+
+    const child = model.processes.find(p => p.id === 'Assembly');
+    assert.ok(child);
+    assert.equal(child.parent, 'Manufacturing');
+  });
+});

--- a/packages/primmel/test/resolver-unit.test.ts
+++ b/packages/primmel/test/resolver-unit.test.ts
@@ -138,6 +138,7 @@ describe('resolve (unit, minimal context)', () => {
       page: null,
       measure: [],
       parent: '',
+      children: [],
       _relations: {
         actor: 'author',
         output: [],


### PR DESCRIPTION
## Summary

Implements lexical process nesting — child process blocks can now appear inside their parent:

```
process Manufacturing {
  name "Manufacture product"

  process Assembly {
    name "Assemble components"
  }
}
```

### Changes

- **Process type**: `children: string[]` (child process IDs)
- **Parser**: Pre-extracts nested `process <Id> { ... }` blocks before `forEachEntry`, recursively parses each child, sets `child.parent = id`
- **Key insight**: `tokenizePackage` calls `unwrapBlock` which strips first/last char (expects brace-wrapped input). Filtered content must be re-wrapped in `{ ... }` before passing to `forEachEntry`
- **Dumper**: New `dumpProcessTree()` emits children inline with indentation. `dump()` filters child processes from the top-level iteration
- **3 new tests**: parse nesting, round-trip dump, field preservation

## Verification

- `yarn compile` — 0 errors
- `yarn lint` — 0 errors
- `yarn test` — 125 pass (122 existing + 3 new), 0 fail
- `yarn build` — clean

## Test plan

- [ ] CI passes
- [ ] Nested model parses and round-trips correctly
- [ ] Existing models (no nesting) still parse and dump identically
