### PR TITLE
Fix include preprocessor: every include after a comment header was skipped

### DIFF
--- a/packages/primmel/src/ser-des/includes.ts
+++ b/packages/primmel/src/ser-des/includes.ts
@@ -58,22 +58,17 @@ export function preprocessIncludes(
   // Replace each include directive with the preprocessed content of
   // the referenced file. Skip comment lines so a `// include "..."` in
   // a comment doesn't get falsely expanded.
-  return content.replace(INCLUDE_RE, (match, includePath: string) => {
-    // Look backward from the match start to the start of the line —
-    // if everything before the match on this line is whitespace
-    // followed by `#` or `//`, the match is inside a comment.
-    const matchEnd = INCLUDE_RE.lastIndex;
-    const lineStart = content.lastIndexOf('\n', matchEnd - match.length) + 1;
-    const prefix = content.slice(lineStart, matchEnd - match.length);
+  return content.replace(INCLUDE_RE, (match, includePath: string, offset: number) => {
+    const lineStart = content.lastIndexOf('\n', offset) + 1;
+    const prefix = content.slice(lineStart, offset);
     if (COMMENT_LINE_RE.test(prefix)) {
-      return match; // in a comment — leave untouched
+      return match;
     }
 
     const resolved = isAbsolute(includePath)
       ? includePath
       : resolve(dir, includePath);
 
-    // Add .mmel extension if not present
     const withExt = resolved.endsWith('.mmel') ? resolved : `${resolved}.mmel`;
 
     return preprocessIncludes(withExt, new Set(_seen));

--- a/packages/primmel/test/includes.test.ts
+++ b/packages/primmel/test/includes.test.ts
@@ -68,4 +68,14 @@ describe('preprocessIncludes', () => {
     const out = preprocessIncludes(join(tmp, 'plain.mmel'));
     assert.equal(out, 'just text\nno includes\n');
   });
+
+  it('does not expand includes inside comments but expands real ones after a comment header', async () => {
+    await writeFile(
+      join(tmp, 'comment-header.mmel'),
+      '// This is a header comment\n// include "should-not-expand.mmel"\n\ninclude "sub/child.mmel"\n',
+    );
+    const out = preprocessIncludes(join(tmp, 'comment-header.mmel'));
+    assert.match(out, /include "should-not-expand\.mmel"/);
+    assert.match(out, /role child/);
+  });
 });


### PR DESCRIPTION
The comment-aware include feature used INCLUDE_RE.lastIndex inside a String.replace() callback, but lastIndex is always 0 in that context. This caused every include after a comment header to be falsely classified as a comment and skipped, producing empty models (0 roles, 0 provisions, etc.).

Fix: use the offset parameter (3rd arg to replace callback) instead. Added a regression test.