### PR TITLE
Bump to 1.3.2

### DIFF
--- a/packages/primmel/package.json
+++ b/packages/primmel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primmel/primmel",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Primmel — parser, types, and serializer for the Primmel modelling language (successor to MMEL)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Version bump for the include preprocessor fix (PR #39). Triggers npm publish via release workflow when tagged.