### PR TITLE
Add conformance_test construct for metrology standards (1.4.0)

### DIFF
--- a/packages/primmel/package.json
+++ b/packages/primmel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primmel/primmel",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "Primmel — parser, types, and serializer for the Primmel modelling language (successor to MMEL)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/primmel/src/ser-des/config/conformanceTest.ts
+++ b/packages/primmel/src/ser-des/config/conformanceTest.ts
@@ -1,0 +1,101 @@
+import ConformanceTest from '../../types/ConformanceTest';
+import { escapeString, unwrapBlock, tokenizePackage } from '../tokenize';
+import { forEachEntry, unwrapped } from '../parse-block';
+import { Dumper, Parser } from '../types';
+
+export const parseConformanceTest: Parser = function (id, data) {
+  const result: ConformanceTest = {
+    id,
+    name: '',
+    type: '',
+    reference: '',
+    targets: [],
+    procedure: [],
+    measurements: [],
+  };
+
+  forEachEntry(
+    data,
+    (keyword, value) => {
+      if (keyword === 'name') {
+        result.name = unwrapped(value);
+      } else if (keyword === 'type') {
+        result.type = value();
+      } else if (keyword === 'reference') {
+        const refValue = value();
+        result.reference = refValue.startsWith('{')
+          ? unwrapBlock(refValue).trim()
+          : refValue;
+      } else if (keyword === 'targets') {
+        result.targets = tokenizePackage(value());
+      } else if (keyword === 'procedure') {
+        const block = value();
+        const tokens = tokenizePackage(block);
+        let i = 0;
+        while (i < tokens.length) {
+          const order = parseInt(tokens[i], 10);
+          if (!isNaN(order) && i + 1 < tokens.length) {
+            const action = unwrapped(() => tokens[i + 1]);
+            result.procedure.push({ order, action });
+            i += 2;
+          } else {
+            i++;
+          }
+        }
+      } else if (keyword === 'validate_measurement') {
+        const block = value();
+        const tokens = tokenizePackage(block);
+        for (const t of tokens) {
+          if (t.startsWith('"')) {
+            result.measurements.push(unwrapBlock(t));
+          }
+        }
+      } else {
+        return false;
+      }
+      return true;
+    },
+    { construct: 'conformance_test', id },
+  );
+
+  return ctx => {
+    ctx.conformanceTests[id] = result;
+    return ctx;
+  };
+};
+
+export const dumpConformanceTest: Dumper<ConformanceTest> = function (ct) {
+  let out = 'conformance_test ' + ct.id + ' {\n';
+  if (ct.name) {
+    out += '  name "' + escapeString(ct.name) + '"\n';
+  }
+  if (ct.type) {
+    out += '  type ' + ct.type + '\n';
+  }
+  if (ct.reference) {
+    out += '  reference ' + ct.reference + '\n';
+  }
+  if (ct.targets.length > 0) {
+    out += '  targets {\n';
+    for (const t of ct.targets) {
+      out += '    ' + t + '\n';
+    }
+    out += '  }\n';
+  }
+  if (ct.procedure.length > 0) {
+    out += '  procedure {\n';
+    for (const step of ct.procedure) {
+      out += '    ' + step.order + ' "' + escapeString(step.action) + '"\n';
+    }
+    out += '  }\n';
+  }
+  if (ct.measurements.length > 0) {
+    out += '  validate_measurement {\n';
+    for (const m of ct.measurements) {
+      out += '    "' + escapeString(m) + '"\n';
+    }
+    out += '  }\n';
+  }
+  out += '}\n';
+  return out;
+};

--- a/packages/primmel/src/ser-des/config/index.ts
+++ b/packages/primmel/src/ser-des/config/index.ts
@@ -75,6 +75,7 @@ import {
   resolveCalculation,
 } from './calculation';
 import { dumpStateMachine, parseStateMachine } from './stateMachine';
+import { dumpConformanceTest, parseConformanceTest } from './conformanceTest';
 import { dumpTerm, parseTerm } from './term';
 
 export interface ConstructDefinition {
@@ -308,6 +309,13 @@ const CONSTRUCTS: ConstructDefinition[] = [
     takesID: true,
     parse: parseStateMachine,
     dump: dumpStateMachine as never,
+  }),
+  defineConstruct({
+    keyword: 'conformance_test',
+    field: 'conformanceTests',
+    takesID: true,
+    parse: parseConformanceTest,
+    dump: dumpConformanceTest as never,
   }),
 ];
 

--- a/packages/primmel/src/ser-des/parse.ts
+++ b/packages/primmel/src/ser-des/parse.ts
@@ -63,6 +63,7 @@ export default function parse(
     symbols: {},
     calculations: {},
     stateMachines: {},
+    conformanceTests: {},
     // Issue collection (duplicate IDs, etc.)
     issues: [],
   };

--- a/packages/primmel/src/ser-des/types.ts
+++ b/packages/primmel/src/ser-des/types.ts
@@ -1,4 +1,5 @@
 import type Calculation from '../types/Calculation';
+import type ConformanceTest from '../types/ConformanceTest';
 import type { DataClass, Enum, Registry, Variable } from '../types/data';
 import EventNode from '../types/events';
 import type Figure from '../types/Figure';
@@ -111,6 +112,7 @@ export interface ParseContext {
   symbols: Record<string, Symbol>;
   calculations: Record<string, Calculation>;
   stateMachines: Record<string, StateMachine>;
+  conformanceTests: Record<string, ConformanceTest>;
 
   // Issues collected during parsing (duplicate IDs, etc.). NOT a model
   // collection — populated by parse() and surfaced via loadWithIssues().

--- a/packages/primmel/src/types/ConformanceTest.ts
+++ b/packages/primmel/src/types/ConformanceTest.ts
@@ -1,0 +1,18 @@
+import type Reference from './Reference';
+
+export interface ConformanceTestStep {
+  order: number;
+  action: string;
+}
+
+export default interface ConformanceTest {
+  id: string;
+  name: string;
+  type: string;
+  reference: string;
+  targets: string[];
+  procedure: ConformanceTestStep[];
+  measurements: string[];
+}
+
+export type { Reference };

--- a/packages/primmel/src/types/Standard.ts
+++ b/packages/primmel/src/types/Standard.ts
@@ -1,5 +1,6 @@
 import type Approval from './Approval';
 import type Calculation from './Calculation';
+import type ConformanceTest from './ConformanceTest';
 import type { DataClass, Enum, Registry, Variable } from './data';
 import EventNode from './events';
 import type Figure from './Figure';
@@ -52,6 +53,7 @@ export default interface Standard {
   symbols: Symbol[];
   calculations: Calculation[];
   stateMachines: StateMachine[];
+  conformanceTests: ConformanceTest[];
 
   root: Subprocess | null;
 }

--- a/packages/primmel/test/conformance-test.test.ts
+++ b/packages/primmel/test/conformance-test.test.ts
@@ -1,0 +1,147 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { load, dump } from '../src/ser-des/index.js';
+
+describe('Conformance tests', () => {
+  it('parses a conformance_test with all fields', () => {
+    const model = load(`root Root
+
+version "v1.0.0"
+
+metadata {
+  title "Test"
+  schema "Primmel 0.1"
+}
+
+start_event Start { }
+end_event Done { }
+
+provision ProvMPE {
+  condition "Errors shall not exceed MPE"
+  modality SHALL
+}
+
+conformance_test MeasurementError {
+  name "Measurement error test"
+  type Testing
+  reference { R60doc#2.10.1 }
+  targets {
+    ProvMPE
+  }
+  procedure {
+    1 "Check test conditions"
+    2 "Insert load cell"
+    3 "Record indications"
+  }
+  validate_measurement {
+    "[error] <= [mpe_limit]"
+  }
+}
+
+canvas Root {
+  elements {
+    Start { x 0 y 0 }
+    Done  { x 0 y 100 }
+  }
+  process_flow {
+    E1 { from Start to Done }
+  }
+}`);
+
+    assert.equal(model.conformanceTests.length, 1);
+    const ct = model.conformanceTests[0];
+    assert.equal(ct.id, 'MeasurementError');
+    assert.equal(ct.name, 'Measurement error test');
+    assert.equal(ct.type, 'Testing');
+    assert.equal(ct.reference, 'R60doc#2.10.1');
+    assert.deepEqual(ct.targets, ['ProvMPE']);
+    assert.equal(ct.procedure.length, 3);
+    assert.equal(ct.procedure[0].order, 1);
+    assert.equal(ct.procedure[0].action, 'Check test conditions');
+    assert.equal(ct.procedure[2].order, 3);
+    assert.equal(ct.procedure[2].action, 'Record indications');
+    assert.deepEqual(ct.measurements, ['[error] <= [mpe_limit]']);
+  });
+
+  it('round-trips through dump', () => {
+    const original = `root Root
+
+version "v1.0.0"
+
+metadata {
+  title "Test"
+  schema "Primmel 0.1"
+}
+
+start_event Start { }
+end_event Done { }
+
+provision ProvMPE {
+  condition "Test"
+  modality SHALL
+}
+
+conformance_test CT1 {
+  name "Test CT"
+  type Inspection
+  targets {
+    ProvMPE
+  }
+  procedure {
+    1 "Step one"
+  }
+}
+
+canvas Root {
+  elements {
+    Start { x 0 y 0 }
+    Done  { x 0 y 100 }
+  }
+  process_flow {
+    E1 { from Start to Done }
+  }
+}`;
+
+    const model = load(original);
+    const dumped = dump(model);
+    assert.ok(dumped.includes('conformance_test CT1'));
+    assert.ok(dumped.includes('name "Test CT"'));
+    assert.ok(dumped.includes('type Inspection'));
+    assert.ok(dumped.includes('1 "Step one"'));
+
+    const reloaded = load(dumped);
+    assert.equal(reloaded.conformanceTests.length, 1);
+    assert.equal(reloaded.conformanceTests[0].procedure.length, 1);
+  });
+
+  it('handles conformance_test without optional fields', () => {
+    const model = load(`root Root
+
+version "v1.0.0"
+
+metadata {
+  title "T"
+  schema "Primmel 0.1"
+}
+
+start_event S { }
+end_event E { }
+
+conformance_test Minimal {
+  name "Minimal test"
+}
+
+canvas Root {
+  elements { S { x 0 y 0 } E { x 0 y 100 } }
+  process_flow { e { from S to E } }
+}`);
+
+    assert.equal(model.conformanceTests.length, 1);
+    const ct = model.conformanceTests[0];
+    assert.equal(ct.id, 'Minimal');
+    assert.equal(ct.name, 'Minimal test');
+    assert.equal(ct.type, '');
+    assert.equal(ct.targets.length, 0);
+    assert.equal(ct.procedure.length, 0);
+  });
+});

--- a/packages/primmel/test/resolver-unit.test.ts
+++ b/packages/primmel/test/resolver-unit.test.ts
@@ -38,6 +38,7 @@ function emptyContext(): ParseContext {
     symbols: {},
     calculations: {},
     stateMachines: {},
+    conformanceTests: {},
     issues: [],
   };
 }


### PR DESCRIPTION
## Summary

New `conformance_test` construct for modeling metrology test procedures. Enables full representation of OIML R 60's conformance test layer.

## Syntax

```text
conformance_test MeasurementErrorTest {
  name "Measurement error test"
  type Testing
  reference { R60doc#2.10.1 }
  targets { ProvMPE ProvRepeatability }
  procedure {
    1 "Check test conditions"
    2 "Insert load cell"
  }
  validate_measurement {
    "[error] <= [mpe_limit]"
  }
}
```

## Changes

- New type: `ConformanceTest` with procedure steps (order + action), targets, validate_measurement
- New parser/dumper registered in CONSTRUCTS
- Added to Standard and ParseContext
- 3 new tests, all 129 pass
- Version 1.4.0

## Verification

- `yarn compile` — 0 errors
- `yarn lint` — 0 errors  
- `yarn test` — 129 pass, 0 fail
- OIML R 60 model updated with 7 conformance tests, all load correctly
